### PR TITLE
fix(render): install devDependencies for Vite build on pulse-frontend

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -72,7 +72,9 @@ services:
     repo: https://github.com/caderichard-debug/Pulse-News
     branch: main
     rootDir: frontend
-    buildCommand: npm install && npm run build
+    # NODE_ENV=production skips devDependencies; vite.config imports @lovable.dev/vite-tanstack-config (devDep).
+    # --include=dev ensures the Vite config loads. Use npm ci for reproducible installs (clear build cache if npm segfaults).
+    buildCommand: npm ci --include=dev && npm run build
     startCommand: npm run preview -- --host 0.0.0.0 --port $PORT
     plan: free
     # Enable PR previews


### PR DESCRIPTION
## Summary
Render sets `NODE_ENV=production` for `pulse-frontend`, so plain `npm install` skipped devDependencies. `vite.config.ts` imports `@lovable.dev/vite-tanstack-config` (a devDependency), which caused `ERR_MODULE_NOT_FOUND` and failed builds.

## Change
- `render.yaml`: `buildCommand` → `npm ci --include=dev && npm run build`

## Notes
- Exit 139 (npm segfault) in logs was associated with a bad build cache; clearing cache on redeploy may help if it recurs.

Related: merged work from [PR #120](https://github.com/caderichard-debug/Pulse-News/pull/120); this commit landed on `render-setup` after that merge.

Made with [Cursor](https://cursor.com)