### PR TITLE
fix(frontend): allow pulsenews.app host for Vite preview

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,4 +6,13 @@
 // You can pass additional config via defineConfig({ vite: { ... } }) if needed.
 import { defineConfig } from "@lovable.dev/vite-tanstack-config";
 
-export default defineConfig();
+export default defineConfig({
+  vite: {
+    server: {
+      allowedHosts: ["pulsenews.app", "www.pulsenews.app", "pulse-frontend-pfrt.onrender.com"],
+    },
+    preview: {
+      allowedHosts: ["pulsenews.app", "www.pulsenews.app", "pulse-frontend-pfrt.onrender.com"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Add allowed hosts for Vite server/preview to support production domain routing on Render.

## Changes
- `frontend/vite.config.ts`
  - Add `server.allowedHosts` and `preview.allowedHosts` with:
    - `pulsenews.app`
    - `www.pulsenews.app`
    - `pulse-frontend-pfrt.onrender.com`

## Why
Render/Vite was rejecting requests with:
"This host (pulsenews.app) is not allowed".
This allows the production domain and Render hostname to pass host checks.