### PR TITLE
fix(backend): don't block health checks on initial scraping

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import re
 from fastapi import FastAPI
@@ -14,31 +15,43 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    # Startup: Create database tables
-    logger.info("Starting Pulse News Aggregator...")
-    create_db_and_tables()
-
-    # Run seed_data if needed (includes initial scraping on first run)
+async def _run_initial_population_in_background():
+    """
+    Run first-time seed/scrape work without blocking app startup.
+    This allows health checks to succeed while heavy initialization runs.
+    """
     try:
         from .seed_data import seed_database, run_initial_scraping
         from sqlmodel import Session, select
         from .models import Article
         from .database import engine
 
-        # Check if we need initial scraping (no articles exist)
-        with Session(engine) as session:
-            existing_articles = session.exec(select(Article)).first()
-            if not existing_articles:
-                logger.info("No articles found - running initial data population...")
-                seed_database()  # Ensure sources/topics/frameworks exist
-                run_initial_scraping()  # Scrape initial articles
-                logger.info("Initial data population complete")
-            else:
-                logger.info("Articles exist - skipping initial scraping")
+        def _populate_if_needed():
+            with Session(engine) as session:
+                existing_articles = session.exec(select(Article)).first()
+                if not existing_articles:
+                    logger.info("No articles found - running initial data population in background...")
+                    seed_database()  # Ensure sources/topics/frameworks exist
+                    run_initial_scraping()  # Scrape initial articles
+                    logger.info("Initial data population complete")
+                else:
+                    logger.info("Articles exist - skipping initial scraping")
+
+        await asyncio.to_thread(_populate_if_needed)
     except Exception as e:
         logger.warning(f"Could not run initial scraping: {e}")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Startup: Create database tables
+    logger.info("Starting Pulse News Aggregator...")
+    create_db_and_tables()
+
+    # Run seed/scrape in background so startup health checks are not blocked.
+    app.state.initial_population_task = asyncio.create_task(
+        _run_initial_population_in_background()
+    )
 
     # Start background job scheduler
     start_scheduler()
@@ -47,6 +60,9 @@ async def lifespan(app: FastAPI):
 
     # Shutdown: Stop scheduler gracefully
     logger.info("Shutting down...")
+    population_task = getattr(app.state, "initial_population_task", None)
+    if population_task and not population_task.done():
+        population_task.cancel()
     stop_scheduler()
 
 


### PR DESCRIPTION
## Summary
- Prevent Render deploy health-check timeouts during backend startup.

## What changed
- `backend/app/main.py`
  - Move first-run seed/scrape population work into a background task.
  - Keep app startup fast so `/health` is available immediately.
  - Cancel background task on shutdown if still running.

## Why
Render was timing out waiting for `.../health` because heavy initialization (initial scraping/analysis) was happening inline during startup.
This change lets health checks pass while initialization continues in parallel.

Made with [Cursor](https://cursor.com)