### PR TITLE
fix(render): start frontend with built server entrypoint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -76,7 +76,9 @@ services:
     # Use NODE_ENV=development only for `npm ci` — avoids `npm ci --include=dev`, which can segfault in
     # Render's npm wrapper on Node 22. `vite build` still runs with service NODE_ENV=production.
     buildCommand: NODE_ENV=development npm ci && npm run build
-    startCommand: npm run preview -- --host 0.0.0.0 --port $PORT
+    # Use the built SSR server entrypoint in production.
+    # `vite preview` is for previewing static builds and fails here with missing dist/server/server.js.
+    startCommand: node dist/server/index.js
     plan: free
     # Enable PR previews
     previews:


### PR DESCRIPTION
## Summary
Fix production runtime "internal server error" on `pulsenews.app`.

## Root cause
`pulse-frontend` was started with `npm run preview` (Vite preview), and runtime logs repeatedly showed:
- `ERR_MODULE_NOT_FOUND`
- Missing `/frontend/dist/server/server.js`

## Change
- `render.yaml` (`pulse-frontend`)
  - `startCommand` changed from Vite preview to:
    - `node dist/server/index.js`

## Why this works
The build already emits `dist/server/index.js` and this is the proper production server entrypoint for this app on Render.

Made with [Cursor](https://cursor.com)