### PR TITLE
fix(render): run frontend with srvx TanStack server runtime

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -75,13 +75,9 @@ services:
     # NODE_ENV=production (below) skips devDependencies; vite + vite.config need devDependencies.
     # Use NODE_ENV=development only for `npm ci` — avoids `npm ci --include=dev`, which can segfault in
     # Render's npm wrapper on Node 22. `vite build` still runs with service NODE_ENV=production.
-    # Build TanStack Start bundles, then generate a static SPA entrypoint for Render web serving.
-    # This project currently emits assets in dist/client but no index.html by default.
-    buildCommand: NODE_ENV=development npm ci && npm run build && node -e "const fs=require('fs');const a='dist/client/assets';const files=fs.readdirSync(a);const js=files.find(f=>/^index-.*\\.js$/.test(f));const css=files.find(f=>/^styles-.*\\.css$/.test(f));if(!js)throw new Error('Missing client index bundle in dist/client/assets');const html='<!doctype html><html><head><meta charset=\"UTF-8\"/><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"/>'+(css?'<link rel=\"stylesheet\" href=\"/assets/'+css+'\"/>':'')+'</head><body><div id=\"root\"></div><script type=\"module\" src=\"/assets/'+js+'\"></script></body></html>';fs.writeFileSync('dist/client/index.html',html);"
-    # Serve the built client bundle as a static SPA.
-    # Previous runtime modes failed on Render (`vite preview` missing dist/server/server.js,
-    # and `node dist/server/index.js` exits early in this build shape).
-    startCommand: npx serve -s dist/client -l $PORT
+    buildCommand: NODE_ENV=development npm ci && npm run build
+    # Run TanStack Start server bundle with srvx (verified locally to return full HTML).
+    startCommand: npx srvx dist/server/index.js --port $PORT
     plan: free
     # Enable PR previews
     previews:


### PR DESCRIPTION
## Summary
Fix blank/white frontend by using the correct runtime for this TanStack Start build.

## Root cause
- Static serving of `dist/client` gave directory listing/blank output.
- The previous SSR command (`node dist/server/index.js`) exited early.

## Change
- `render.yaml` (`pulse-frontend`):
  - `buildCommand`: `NODE_ENV=development npm ci && npm run build`
  - `startCommand`: `npx srvx dist/server/index.js --port $PORT`

## Verification
Locally, `srvx dist/server/index.js` returns full HTML (SSR response) instead of a blank page.

Made with [Cursor](https://cursor.com)