### PR TITLE
fix(render): map srvx public assets at runtime

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -76,9 +76,9 @@ services:
     # Use NODE_ENV=development only for `npm ci` — avoids `npm ci --include=dev`, which can segfault in
     # Render's npm wrapper on Node 22. `vite build` still runs with service NODE_ENV=production.
     buildCommand: NODE_ENV=development npm ci && npm run build
-    # Ensure srvx default static root exists at runtime and points to built client assets.
-    # This prevents /assets/* 404s that cause unstyled pages.
-    startCommand: mkdir -p public && rm -rf public/assets && ln -s dist/client/assets public/assets && npx srvx serve --entry dist/server/index.js --port $PORT --prod
+    # Explicitly serve static assets from dist/client so /assets/* resolves in production.
+    # This avoids relying on srvx's default static root ("public"), which caused CSS/JS 404s.
+    startCommand: npx srvx serve --entry dist/server/index.js --static dist/client --port $PORT --prod
     plan: free
     # Enable PR previews
     previews:

--- a/render.yaml
+++ b/render.yaml
@@ -75,10 +75,10 @@ services:
     # NODE_ENV=production (below) skips devDependencies; vite + vite.config need devDependencies.
     # Use NODE_ENV=development only for `npm ci` — avoids `npm ci --include=dev`, which can segfault in
     # Render's npm wrapper on Node 22. `vite build` still runs with service NODE_ENV=production.
-    # Build app and copy client assets to srvx default static root (`public/`).
-    # srvx in Render is serving from `public/`, so SSR references to `/assets/*` must exist there.
-    buildCommand: NODE_ENV=development npm ci && npm run build && mkdir -p public && rm -rf public/assets && cp -R dist/client/assets public/assets
-    startCommand: npx srvx serve --entry dist/server/index.js --port $PORT --prod
+    buildCommand: NODE_ENV=development npm ci && npm run build
+    # Ensure srvx default static root exists at runtime and points to built client assets.
+    # This prevents /assets/* 404s that cause unstyled pages.
+    startCommand: mkdir -p public && rm -rf public/assets && ln -s dist/client/assets public/assets && npx srvx serve --entry dist/server/index.js --port $PORT --prod
     plan: free
     # Enable PR previews
     previews:


### PR DESCRIPTION
## Summary
- remove brittle build-time asset copy into `public/`
- create `public/assets` symlink to `dist/client/assets` in `startCommand`
- keep srvx SSR entry while ensuring `/assets/*` resolves at runtime

## Test plan
- deploy pulse-frontend on Render
- open https://pulsenews.app and verify CSS/JS load
- confirm Render logs stop showing `/assets/*` 404 responses

Made with [Cursor](https://cursor.com)