### PR TITLE
feat: restore newsletter links, fact-check fallback, and analytics scoping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,12 @@ MAX_FRAMEWORKS_PER_NEWSLETTER=3
 
 # Documentation Links
 DOCUMENTATION_URL=https://docs.pulsenews.app
+
+# Fact-check HTML search (PolitiFact / Snopes; no official API — HTML can change)
+# Set FACT_CHECK_ENABLE_SCRAPING=false in strict production until validated in your environment.
+FACT_CHECK_ENABLE_SCRAPING=true
+FACT_CHECK_SCRAPE_USER_AGENT=
+
+# Google Fact Check Tools + ClaimBuster (optional)
+GOOGLE_FACT_CHECK_API_KEY=
+CLAIMBUSTER_API_KEY=

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -23,6 +23,9 @@ class Settings(BaseSettings):
     google_fact_check_api_key: Optional[str] = None
     google_search_engine_id: Optional[str] = None  # For Google Custom Search
     claimbuster_api_key: Optional[str] = None
+    # Lightweight PolitiFact/Snopes search HTML (no official API); disable in strict prod if desired
+    fact_check_enable_scraping: bool = True
+    fact_check_scrape_user_agent: Optional[str] = None
 
     # Email Configuration
     from_email: str = "newsletter@pulsenews.app"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 from .database import create_db_and_tables
 from .jobs.scheduler import start_scheduler, stop_scheduler
-from .routes import admin, auth, preferences, articles, test_email, analytics, feed, sources, admin_panel, password_reset, analyze, favorites, oauth, challenge
+from .routes import admin, auth, preferences, articles, test_email, analytics, feed, sources, admin_panel, password_reset, analyze, favorites, oauth, challenge, newsletter_links
 import logging
 from .config import settings
 
@@ -101,6 +101,7 @@ app.include_router(sources.router)
 app.include_router(analyze.router)  # Article URL analysis
 app.include_router(favorites.router)  # Favorites/bookmarking
 app.include_router(challenge.router)  # Weekly challenge system
+app.include_router(newsletter_links.router)  # Signed newsletter unsubscribe / preferences links
 
 
 @app.get("/")

--- a/backend/app/routes/analytics.py
+++ b/backend/app/routes/analytics.py
@@ -3,11 +3,13 @@ Analytics routes for dashboard data visualization.
 """
 
 from fastapi import APIRouter, Depends, Query
+from sqlalchemy import or_
 from sqlmodel import Session, select, func
 from ..database import get_session
 from ..models import (
     User, Article, ArticleAnalysis, ArticleFrameworkLink,
-    Framework, Topic, UserTopicPreference, PoliticalLean
+    Framework, UserTopicPreference,
+    UserSourceSubscription, ArticleTopicLink,
 )
 from ..routes.auth import get_current_user
 from pydantic import BaseModel
@@ -17,6 +19,40 @@ import logging
 
 router = APIRouter(prefix="/analytics", tags=["analytics"])
 logger = logging.getLogger(__name__)
+
+
+def _user_reading_scope_filter(session: Session, user: User):
+    """
+    Articles that match the user's subscribed sources OR preferred topics (via ArticleTopicLink).
+    Returns None if the user has no subscriptions and no topic preferences (caller treats as no filter).
+    """
+    source_ids = session.exec(
+        select(UserSourceSubscription.source_id).where(
+            UserSourceSubscription.user_id == user.id,
+            UserSourceSubscription.subscribed == True,
+        )
+    ).all()
+
+    topic_article_ids = session.exec(
+        select(ArticleTopicLink.article_id)
+        .join(
+            UserTopicPreference,
+            UserTopicPreference.topic_id == ArticleTopicLink.topic_id,
+        )
+        .where(UserTopicPreference.user_id == user.id)
+    ).all()
+
+    clauses = []
+    if source_ids:
+        clauses.append(Article.source_id.in_(source_ids))
+    if topic_article_ids:
+        clauses.append(Article.id.in_(topic_article_ids))
+
+    if not clauses:
+        return None
+    if len(clauses) == 1:
+        return clauses[0]
+    return or_(*clauses)
 
 
 # Response Models
@@ -52,6 +88,11 @@ async def get_sentiment_over_time(
     current_user: User = Depends(get_current_user),
     days: int = Query(default=30, ge=1, le=90),
     topic_ids: Optional[str] = Query(default=None, description="Comma-separated topic IDs (currently unused)"),
+    scope: str = Query(
+        default="user",
+        description="user: articles from subscribed sources / preferred topics; global: all analyzed articles",
+        pattern="^(user|global)$",
+    ),
     session: Session = Depends(get_session)
 ):
     """
@@ -68,6 +109,11 @@ async def get_sentiment_over_time(
 
     Note: Currently groups by political lean instead of topics since articles
     don't have topic_category assigned yet.
+
+    With ``scope=user``, articles are limited to subscribed sources and/or
+    preferred topics (via article–topic links). If the user has neither, the
+    result is empty (not global aggregates). Use ``scope=global`` for the
+    previous all-articles behavior.
     """
     # Calculate date range
     end_date = datetime.utcnow().date()
@@ -80,7 +126,14 @@ async def get_sentiment_over_time(
         .where(Article.published_at >= start_date)
     )
 
-    results = session.exec(query).all()
+    if scope == "user":
+        filt = _user_reading_scope_filter(session, current_user)
+        if filt is None:
+            results = []
+        else:
+            results = session.exec(query.where(filt)).all()
+    else:
+        results = session.exec(query).all()
 
     # Group by date and political lean in Python
     result_data = {}
@@ -116,6 +169,11 @@ async def get_sentiment_over_time(
 async def get_bias_distribution(
     current_user: User = Depends(get_current_user),
     weeks: int = Query(default=4, ge=1, le=12),
+    scope: str = Query(
+        default="user",
+        description="user: articles from subscribed sources / preferred topics; global: all analyzed articles",
+        pattern="^(user|global)$",
+    ),
     session: Session = Depends(get_session)
 ):
     """
@@ -131,6 +189,9 @@ async def get_bias_distribution(
       },
       ...
     ]
+
+    ``scope=user`` uses the same reading scope as sentiment-over-time; empty
+    when the user has no subscriptions and no topic preferences.
     """
     # Calculate date range
     end_date = datetime.utcnow().date()
@@ -143,7 +204,14 @@ async def get_bias_distribution(
         .where(Article.published_at >= start_date)
     )
 
-    results = session.exec(query).all()
+    if scope == "user":
+        filt = _user_reading_scope_filter(session, current_user)
+        if filt is None:
+            results = []
+        else:
+            results = session.exec(query.where(filt)).all()
+    else:
+        results = session.exec(query).all()
 
     # Group by week in Python (works with SQLite and PostgreSQL)
     weekly_data = {}

--- a/backend/app/routes/newsletter_links.py
+++ b/backend/app/routes/newsletter_links.py
@@ -1,0 +1,83 @@
+"""
+Public newsletter action links (signed tokens from email).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import jwt
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlmodel import Session
+
+from ..config import settings
+from ..database import get_session
+from ..models import User
+from ..utils.newsletter_token import decode_newsletter_token
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/newsletter", tags=["newsletter"])
+
+
+def _invalid_token_response() -> HTMLResponse:
+    return HTMLResponse(
+        content=(
+            "<html><body><p>This link is invalid or has expired.</p>"
+            "<p>You can still change email settings in the Pulse app.</p></body></html>"
+        ),
+        status_code=400,
+    )
+
+
+@router.get("/unsubscribe", response_class=HTMLResponse)
+def newsletter_unsubscribe(
+    token: str = Query(..., description="Signed token from newsletter email"),
+    session: Session = Depends(get_session),
+):
+    try:
+        data = decode_newsletter_token(token)
+    except jwt.PyJWTError as e:
+        logger.info("Newsletter unsubscribe: bad token: %s", e)
+        return _invalid_token_response()
+
+    if data.get("pur") != "unsubscribe":
+        return _invalid_token_response()
+
+    user = session.get(User, int(data["uid"]))
+    if not user:
+        return HTMLResponse(
+            "<html><body><p>Account not found.</p></body></html>",
+            status_code=404,
+        )
+
+    user.newsletter_enabled = False
+    session.add(user)
+    session.commit()
+
+    return HTMLResponse(
+        content=(
+            "<html><body><p>You have been unsubscribed from Pulse newsletters.</p>"
+            "<p>You can re-enable them anytime in your account preferences.</p></body></html>"
+        ),
+        status_code=200,
+    )
+
+
+@router.get("/preferences")
+def newsletter_preferences_redirect(
+    token: str = Query(..., description="Signed token from newsletter email"),
+):
+    try:
+        data = decode_newsletter_token(token)
+    except jwt.PyJWTError as e:
+        logger.info("Newsletter preferences: bad token: %s", e)
+        raise HTTPException(status_code=400, detail="Invalid or expired link") from e
+
+    if data.get("pur") != "preferences":
+        raise HTTPException(status_code=400, detail="Invalid link")
+
+    base = settings.frontend_url.rstrip("/")
+    url = f"{base}/preferences?newsletter_token={token}"
+    return RedirectResponse(url=url, status_code=302)

--- a/backend/app/services/ai_analyzer.py
+++ b/backend/app/services/ai_analyzer.py
@@ -6,6 +6,7 @@ Generates summaries, sentiment analysis, bias detection, and extracts key statis
 from sqlmodel import Session, select
 from ..models import Article, ArticleAnalysis, ProcessingStatus, PoliticalLean, Topic, ArticleTopicLink
 from ..database import engine
+from ..services.statistics_verifier import process_article_statistics
 from ..utils.openai_client import openai_client
 from datetime import datetime
 from typing import List, Optional
@@ -133,7 +134,7 @@ def analyze_articles_batch(session: Session, batch_size: int = 5) -> int:
                 political_lean=political_lean,
                 bias_indicators=analysis_data.get('bias_indicators'),
                 key_stats=str(analysis_data.get('key_stats')) if analysis_data.get('key_stats') else None,
-                stats_verified=None,  # TODO: Implement stats verification
+                stats_verified=False,
                 processing_cost=0.002,  # Approximate cost per article
                 tokens_used=None,  # We don't track individual tokens in batch
                 processed_at=datetime.utcnow()
@@ -154,6 +155,19 @@ def analyze_articles_batch(session: Session, batch_size: int = 5) -> int:
     # Commit all analyses
     session.commit()
     logger.info(f"Successfully analyzed {analyzed_count}/{len(articles_to_analyze)} articles")
+
+    for article in articles_to_analyze:
+        try:
+            with Session(engine) as stat_session:
+                art = stat_session.get(Article, article.id)
+                if art:
+                    process_article_statistics(art, stat_session)
+        except Exception as e:
+            logger.warning(
+                "Post-analysis statistics pipeline failed for article %s: %s",
+                article.id,
+                e,
+            )
 
     return analyzed_count
 

--- a/backend/app/services/fact_check_integrator.py
+++ b/backend/app/services/fact_check_integrator.py
@@ -5,7 +5,7 @@ Integrates with external fact-checking APIs to verify statistics.
 Supports:
 - Google Fact Check Tools API
 - ClaimBuster API
-- Future: PolitiFact, Snopes (web scraping)
+- Optional PolitiFact / Snopes HTML search (see FACT_CHECK_ENABLE_SCRAPING)
 """
 
 import logging
@@ -15,8 +15,14 @@ from urllib.parse import quote
 from datetime import datetime
 
 from ..config import settings
+from .fact_check_scrape.politifact import search_politifact_claim
+from .fact_check_scrape.snopes import search_snopes_claim
+from .fact_check_scrape.rating_parser import parse_textual_rating_to_status
 
 logger = logging.getLogger(__name__)
+
+# Prefer structured API results unless confidence is below this (then try HTML scrapers).
+_SCRAPE_FALLBACK_MAX_CONFIDENCE = 0.55
 
 
 class FactCheckIntegrator:
@@ -47,7 +53,7 @@ class FactCheckIntegrator:
                 - confidence: 0.0 to 1.0
             Returns None if no fact-check found
         """
-        results = []
+        results: List[Dict] = []
 
         # Try Google Fact Check Tools first (best coverage)
         if self.google_api_key:
@@ -61,13 +67,33 @@ class FactCheckIntegrator:
             if claimbuster_result:
                 results.append(claimbuster_result)
 
-        # Select best result
-        if not results:
+        def _best(rs: List[Dict]) -> Optional[Dict]:
+            if not rs:
+                return None
+            return max(rs, key=lambda r: r.get("confidence", 0.0))
+
+        best_result = _best(results)
+
+        # Lightweight HTML search when APIs miss or yield low-confidence only
+        if getattr(settings, "fact_check_enable_scraping", True):
+            ua = settings.fact_check_scrape_user_agent or (
+                "PulseNews/1.0 (+https://pulsenews.app; fact-check verification)"
+            )
+            need_scrape = best_result is None or best_result.get("confidence", 0.0) < _SCRAPE_FALLBACK_MAX_CONFIDENCE
+            if need_scrape:
+                pf = self._check_politifact_web_scraping(statistic_text, user_agent=ua)
+                if pf:
+                    results.append(pf)
+                    best_result = _best(results)
+                if best_result is None or best_result.get("confidence", 0.0) < _SCRAPE_FALLBACK_MAX_CONFIDENCE:
+                    sn = self._check_snopes_web_scraping(statistic_text, user_agent=ua)
+                    if sn:
+                        results.append(sn)
+                        best_result = _best(results)
+
+        if not best_result:
             logger.debug(f"No fact-check found for: {statistic_text[:50]}")
             return None
-
-        # Prefer results with higher confidence
-        best_result = max(results, key=lambda r: r.get("confidence", 0.0))
 
         logger.info(
             f"Fact-check found via {best_result['fact_check_source']}: "
@@ -112,7 +138,7 @@ class FactCheckIntegrator:
 
             # Extract rating
             rating_text = claim_review.get("textualRating", "").lower()
-            status = self._parse_google_rating(rating_text)
+            status = parse_textual_rating_to_status(rating_text)
 
             # Calculate confidence based on publisher and rating clarity
             confidence = 0.7
@@ -134,40 +160,6 @@ class FactCheckIntegrator:
         except Exception as e:
             logger.error(f"Error parsing Google Fact Check response: {e}")
             return None
-
-    def _parse_google_rating(self, rating_text: str) -> str:
-        """
-        Parse Google Fact Check rating into our standard statuses.
-
-        Common ratings: "True", "False", "Mostly True", "Mostly False",
-        "Half True", "Mixture", "Unproven", etc.
-        """
-        rating_lower = rating_text.lower()
-
-        # Check for false/incorrect first (to avoid "incorrect" matching "correct")
-        if any(word in rating_lower for word in ["false", "incorrect", "inaccurate", "pants on fire"]):
-            if any(word in rating_lower for word in ["mostly"]):
-                return "mixed"
-            else:
-                return "false"
-
-        # Check for mixture/mixed/half
-        if any(word in rating_lower for word in ["mixture", "mixed", "half"]):
-            return "mixed"
-
-        # Check for true/correct/accurate
-        if any(word in rating_lower for word in ["true", "correct", "accurate"]):
-            if any(word in rating_lower for word in ["mostly", "partially"]):
-                return "mixed"
-            else:
-                return "verified"
-
-        # Check for unproven
-        if any(word in rating_lower for word in ["unproven", "unclear", "unsupported"]):
-            return "unverifiable"
-
-        # Default to unverifiable if we can't parse the rating
-        return "unverifiable"
 
     def _check_claimbuster(self, claim: str) -> Optional[Dict]:
         """
@@ -228,27 +220,23 @@ class FactCheckIntegrator:
             logger.error(f"Error parsing ClaimBuster response: {e}")
             return None
 
-    def _check_politifact_web_scraping(self, claim: str) -> Optional[Dict]:
+    def _check_politifact_web_scraping(self, claim: str, user_agent: str) -> Optional[Dict]:
         """
-        Search PolitiFact via web scraping (no official API).
+        Search PolitiFact (HTML search). Layouts can change; failures are non-fatal.
+        """
+        try:
+            return search_politifact_claim(claim, user_agent=user_agent)
+        except Exception as e:
+            logger.debug("PolitiFact scrape error: %s", e)
+            return None
 
-        Note: This is a placeholder for future implementation.
-        Would require Beautiful Soup and careful parsing of search results.
-        """
-        # TODO: Implement web scraping for PolitiFact
-        logger.debug("PolitiFact web scraping not yet implemented")
-        return None
-
-    def _check_snopes_web_scraping(self, claim: str) -> Optional[Dict]:
-        """
-        Search Snopes via web scraping (no official API).
-
-        Note: This is a placeholder for future implementation.
-        Would require Beautiful Soup and careful parsing of search results.
-        """
-        # TODO: Implement web scraping for Snopes
-        logger.debug("Snopes web scraping not yet implemented")
-        return None
+    def _check_snopes_web_scraping(self, claim: str, user_agent: str) -> Optional[Dict]:
+        """Search Snopes (HTML search). Layouts can change; failures are non-fatal."""
+        try:
+            return search_snopes_claim(claim, user_agent=user_agent)
+        except Exception as e:
+            logger.debug("Snopes scrape error: %s", e)
+            return None
 
 
 # Singleton instance

--- a/backend/app/services/fact_check_scrape/__init__.py
+++ b/backend/app/services/fact_check_scrape/__init__.py
@@ -1,0 +1,11 @@
+"""Lightweight HTML search clients for fact-check sites (no official APIs)."""
+
+from .politifact import search_politifact_claim
+from .snopes import search_snopes_claim
+from .rating_parser import parse_textual_rating_to_status
+
+__all__ = [
+    "search_politifact_claim",
+    "search_snopes_claim",
+    "parse_textual_rating_to_status",
+]

--- a/backend/app/services/fact_check_scrape/politifact.py
+++ b/backend/app/services/fact_check_scrape/politifact.py
@@ -1,0 +1,152 @@
+"""
+Lightweight PolitiFact search scrape (no official API).
+HTML layouts change; parsing is defensive. Site policy: use sparingly, low QPS.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Callable, Optional
+from urllib.parse import quote_plus
+
+import requests
+from bs4 import BeautifulSoup
+
+from .rating_parser import parse_textual_rating_to_status
+
+logger = logging.getLogger(__name__)
+
+POLITIFACT_SEARCH = "https://www.politifact.com/search/"
+# Avoid downloading huge pages
+MAX_RESPONSE_BYTES = 600_000
+DEFAULT_TIMEOUT = 8
+MAX_CANDIDATES = 3
+
+
+def _default_headers(user_agent: str) -> dict:
+    return {
+        "User-Agent": user_agent,
+        "Accept": "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+    }
+
+
+def _truncate(s: str, max_len: int = 400) -> str:
+    s = (s or "").strip()
+    if len(s) <= max_len:
+        return s
+    return s[: max_len - 3] + "..."
+
+
+def parse_politifact_search_html(
+    html: str,
+    base_url: str = "https://www.politifact.com",
+) -> Optional[dict]:
+    """
+    Parse PolitiFact search results HTML. Returns fact-check dict or None.
+
+    Looks for factcheck article links and optional rating/snippet text.
+    """
+    if not html or len(html) < 200:
+        return None
+
+    try:
+        soup = BeautifulSoup(html, "html.parser")
+    except Exception as e:  # pragma: no cover - bs4 rarely fails
+        logger.debug("PolitiFact parse soup error: %s", e)
+        return None
+
+    candidates = []
+    for a in soup.find_all("a", href=True):
+        href = a.get("href", "").strip()
+        if not href or "/factchecks/" not in href.lower():
+            continue
+        if href.startswith("//"):
+            href = "https:" + href
+        elif href.startswith("/"):
+            href = base_url.rstrip("/") + href
+        text = _truncate(a.get_text(" ", strip=True) or "")
+        if not text or len(text) < 8:
+            continue
+        if href in {c[0] for c in candidates}:
+            continue
+        candidates.append((href, text, a))
+        if len(candidates) >= MAX_CANDIDATES:
+            break
+
+    if not candidates:
+        return None
+
+    url, title, first_a = candidates[0]
+    # Sniff rating from nearby text (listing cards often include meter label)
+    rating_guess = ""
+    parent = first_a.parent if first_a else None
+    if parent:
+        block = parent.get_text(" ", strip=True)
+        for token in (
+            "True",
+            "False",
+            "Mostly True",
+            "Mostly False",
+            "Half True",
+            "Pants on Fire",
+            "Mostly False",
+        ):
+            if token.lower() in block.lower():
+                rating_guess = token
+                break
+
+    status = parse_textual_rating_to_status(rating_guess) if rating_guess else "unverifiable"
+    confidence = 0.72 if rating_guess else 0.52
+
+    return {
+        "fact_check_status": status,
+        "fact_check_source": "politifact_scrape",
+        "fact_check_url": url,
+        "fact_check_details": _truncate(f"PolitiFact: {title}" + (f" — {rating_guess}" if rating_guess else "")),
+        "confidence": confidence,
+    }
+
+
+def search_politifact_claim(
+    claim: str,
+    *,
+    timeout: int = DEFAULT_TIMEOUT,
+    user_agent: str = "PulseNews/1.0 (+https://pulsenews.app; fact-check verification)",
+    get: Optional[Callable] = None,
+) -> Optional[dict]:
+    """
+    GET PolitiFact search for claim; parse first factcheck links.
+
+    `get` is injectable for tests (signature: get(url, **kwargs) -> object with .text, .content, .status_code).
+    """
+    if not claim or not claim.strip():
+        return None
+
+    q = quote_plus(claim.strip()[:500])
+    url = f"{POLITIFACT_SEARCH}?q={q}"
+    getter = get or requests.get
+
+    try:
+        resp = getter(
+            url,
+            timeout=timeout,
+            headers=_default_headers(user_agent),
+        )
+        if getattr(resp, "status_code", 200) != 200:
+            logger.debug("PolitiFact search HTTP %s", getattr(resp, "status_code", "?"))
+            return None
+        raw = getattr(resp, "content", b"") or b""
+        if len(raw) > MAX_RESPONSE_BYTES:
+            raw = raw[:MAX_RESPONSE_BYTES]
+        text = raw.decode("utf-8", errors="replace")
+        # Strip scripts for faster parse (optional)
+        text = re.sub(r"<script[^>]*>[\s\S]*?</script>", "", text, flags=re.I)
+        return parse_politifact_search_html(text)
+    except requests.RequestException as e:
+        logger.debug("PolitiFact search request failed: %s", e)
+        return None
+    except Exception as e:
+        logger.debug("PolitiFact search unexpected error: %s", e)
+        return None

--- a/backend/app/services/fact_check_scrape/rating_parser.py
+++ b/backend/app/services/fact_check_scrape/rating_parser.py
@@ -1,0 +1,34 @@
+"""
+Map textual fact-check ratings to Pulse status codes.
+Shared by Google Fact Check integration and HTML scrapers.
+"""
+
+
+def parse_textual_rating_to_status(rating_text: str) -> str:
+    """
+    Parse a textual rating into: verified | false | mixed | unverifiable.
+
+    Handles PolitiFact, Snopes, Google, and common variants.
+    """
+    if not rating_text:
+        return "unverifiable"
+
+    rating_lower = rating_text.lower()
+
+    if any(word in rating_lower for word in ["false", "incorrect", "inaccurate", "pants on fire"]):
+        if any(word in rating_lower for word in ["mostly"]):
+            return "mixed"
+        return "false"
+
+    if any(word in rating_lower for word in ["mixture", "mixed", "half"]):
+        return "mixed"
+
+    if any(word in rating_lower for word in ["true", "correct", "accurate"]):
+        if any(word in rating_lower for word in ["mostly", "partially"]):
+            return "mixed"
+        return "verified"
+
+    if any(word in rating_lower for word in ["unproven", "unclear", "unsupported", "undetermined"]):
+        return "unverifiable"
+
+    return "unverifiable"

--- a/backend/app/services/fact_check_scrape/snopes.py
+++ b/backend/app/services/fact_check_scrape/snopes.py
@@ -1,0 +1,150 @@
+"""
+Lightweight Snopes search scrape (no official API).
+Defensive parsing; layouts change.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Callable, Optional
+from urllib.parse import quote_plus
+
+import requests
+from bs4 import BeautifulSoup
+
+from .rating_parser import parse_textual_rating_to_status
+
+logger = logging.getLogger(__name__)
+
+SNOPES_SEARCH = "https://www.snopes.com/"
+MAX_RESPONSE_BYTES = 600_000
+DEFAULT_TIMEOUT = 8
+MAX_CANDIDATES = 3
+
+
+def _default_headers(user_agent: str) -> dict:
+    return {
+        "User-Agent": user_agent,
+        "Accept": "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+    }
+
+
+def _truncate(s: str, max_len: int = 400) -> str:
+    s = (s or "").strip()
+    if len(s) <= max_len:
+        return s
+    return s[: max_len - 3] + "..."
+
+
+def _normalize_snopes_href(href: str, base: str = "https://www.snopes.com") -> Optional[str]:
+    href = href.strip()
+    if not href:
+        return None
+    if "/fact-check/" not in href.lower() and "/fact_check/" not in href.lower():
+        return None
+    if href.startswith("//"):
+        return "https:" + href
+    if href.startswith("/"):
+        return base.rstrip("/") + href
+    if href.startswith("http"):
+        return href
+    return None
+
+
+def parse_snopes_search_html(html: str) -> Optional[dict]:
+    """Parse Snopes search / listing HTML for first fact-check links."""
+    if not html or len(html) < 200:
+        return None
+
+    try:
+        soup = BeautifulSoup(html, "html.parser")
+    except Exception as e:  # pragma: no cover
+        logger.debug("Snopes parse soup error: %s", e)
+        return None
+
+    candidates = []
+    for a in soup.find_all("a", href=True):
+        full = _normalize_snopes_href(a["href"])
+        if not full:
+            continue
+        text = _truncate(a.get_text(" ", strip=True) or "")
+        if len(text) < 6:
+            continue
+        if full in {c[0] for c in candidates}:
+            continue
+        candidates.append((full, text, a))
+        if len(candidates) >= MAX_CANDIDATES:
+            break
+
+    if not candidates:
+        return None
+
+    url, title, first_a = candidates[0]
+    rating_guess = ""
+    parent = first_a.parent if first_a else None
+    if parent:
+        block = parent.get_text(" ", strip=True)
+        for token in (
+            "True",
+            "False",
+            "Mostly True",
+            "Mostly False",
+            "Mixture",
+            "Unproven",
+            "Miscaptioned",
+            "Correct Attribution",
+        ):
+            if token.lower() in block.lower():
+                rating_guess = token
+                break
+
+    status = parse_textual_rating_to_status(rating_guess) if rating_guess else "unverifiable"
+    confidence = 0.7 if rating_guess else 0.5
+
+    return {
+        "fact_check_status": status,
+        "fact_check_source": "snopes_scrape",
+        "fact_check_url": url,
+        "fact_check_details": _truncate(
+            f"Snopes: {title}" + (f" — {rating_guess}" if rating_guess else "")
+        ),
+        "confidence": confidence,
+    }
+
+
+def search_snopes_claim(
+    claim: str,
+    *,
+    timeout: int = DEFAULT_TIMEOUT,
+    user_agent: str = "PulseNews/1.0 (+https://pulsenews.app; fact-check verification)",
+    get: Optional[Callable] = None,
+) -> Optional[dict]:
+    """
+    GET Snopes site search. WordPress default uses ?s= query on homepage.
+    """
+    if not claim or not claim.strip():
+        return None
+
+    q = quote_plus(claim.strip()[:500])
+    url = f"{SNOPES_SEARCH}?s={q}"
+    getter = get or requests.get
+
+    try:
+        resp = getter(url, timeout=timeout, headers=_default_headers(user_agent))
+        if getattr(resp, "status_code", 200) != 200:
+            logger.debug("Snopes search HTTP %s", getattr(resp, "status_code", "?"))
+            return None
+        raw = getattr(resp, "content", b"") or b""
+        if len(raw) > MAX_RESPONSE_BYTES:
+            raw = raw[:MAX_RESPONSE_BYTES]
+        text = raw.decode("utf-8", errors="replace")
+        text = re.sub(r"<script[^>]*>[\s\S]*?</script>", "", text, flags=re.I)
+        return parse_snopes_search_html(text)
+    except requests.RequestException as e:
+        logger.debug("Snopes search request failed: %s", e)
+        return None
+    except Exception as e:
+        logger.debug("Snopes search unexpected error: %s", e)
+        return None

--- a/backend/app/services/framework_generator.py
+++ b/backend/app/services/framework_generator.py
@@ -3,7 +3,7 @@ Framework generation and article mapping service.
 This is the "competitive edge" - mapping articles to underlying ethical debates.
 """
 
-from sqlmodel import Session, select
+from sqlmodel import Session, select, func
 from ..models import (
     Article, ArticleAnalysis, Framework, ArticleFrameworkLink
 )
@@ -15,6 +15,22 @@ import logging
 import json
 
 logger = logging.getLogger(__name__)
+
+
+def refresh_framework_article_counts(session: Session) -> None:
+    """
+    Recompute Framework.article_count from ArticleFrameworkLink rows.
+    Call after mapping commits or as a maintenance reconcile.
+    """
+    frameworks = session.exec(select(Framework)).all()
+    for fw in frameworks:
+        cnt = session.exec(
+            select(func.count())
+            .select_from(ArticleFrameworkLink)
+            .where(ArticleFrameworkLink.framework_id == fw.id)
+        ).one()
+        fw.article_count = int(cnt or 0)
+        session.add(fw)
 
 
 def map_articles_to_frameworks(
@@ -144,8 +160,12 @@ def map_articles_to_frameworks(
             logger.error(f"Error mapping article {article.id}: {e}")
             continue
 
+    session.flush()
+    refresh_framework_article_counts(session)
     session.commit()
-    logger.info(f"Created {mappings_created} framework mappings")
+    logger.info(
+        f"Created {mappings_created} framework mappings; refreshed framework article_count"
+    )
 
     return mappings_created
 

--- a/backend/app/services/newsletter_service.py
+++ b/backend/app/services/newsletter_service.py
@@ -12,6 +12,7 @@ from ..models import (
 )
 from ..database import engine
 from ..config import settings
+from ..utils.newsletter_token import create_newsletter_token
 from datetime import datetime, timedelta
 from typing import List, Dict, Optional
 import logging
@@ -295,6 +296,9 @@ def _generate_newsletter_for_user(user: User, session: Session) -> Optional[Dict
 
     # Prepare template data
     frontend_url = os.getenv("FRONTEND_URL", "http://localhost:3000")
+    backend_base = settings.backend_url.rstrip("/")
+    prefs_token = create_newsletter_token(user.id, "preferences")
+    unsub_token = create_newsletter_token(user.id, "unsubscribe")
 
     # Add Friday challenge section if applicable
     challenge = None
@@ -318,10 +322,10 @@ def _generate_newsletter_for_user(user: User, session: Session) -> Optional[Dict
         ],
         "articles": [],
         "challenge": challenge,  # Will be None except on Fridays for opted-in users
-        "preferences_url": f"{frontend_url}/preferences?token={user.email}",  # TODO: Add real token
+        "preferences_url": f"{backend_base}/newsletter/preferences?token={prefs_token}",
         "website_url": frontend_url,
         "documentation_url": os.getenv("DOCUMENTATION_URL", "https://docs.pulsenews.app"),
-        "unsubscribe_url": f"{frontend_url}/unsubscribe?token={user.email}"  # TODO: Add real token
+        "unsubscribe_url": f"{backend_base}/newsletter/unsubscribe?token={unsub_token}",
     }
 
     # Add article data with enhancements

--- a/backend/app/services/statistics_verifier.py
+++ b/backend/app/services/statistics_verifier.py
@@ -29,6 +29,9 @@ openai_api = OpenAI(api_key=settings.openai_api_key) if settings.openai_api_key 
 
 logger = logging.getLogger(__name__)
 
+# Cap per article to keep batch analysis and verification bounded.
+MAX_STATISTICS_PER_ARTICLE = 5
+
 
 STATISTICS_EXTRACTION_PROMPT = """Analyze this article and extract ALL quantifiable claims, statistics, and factual assertions.
 
@@ -146,6 +149,13 @@ def extract_statistics_from_article(
         if len(statistics) == 0:
             logger.info(f"[EXTRACT] Article {article.id} - No statistics found by AI")
             return []
+
+        if len(statistics) > MAX_STATISTICS_PER_ARTICLE:
+            logger.info(
+                f"[EXTRACT] Article {article.id} - Capping statistics "
+                f"from {len(statistics)} to {MAX_STATISTICS_PER_ARTICLE}"
+            )
+            statistics = statistics[:MAX_STATISTICS_PER_ARTICLE]
 
         # Create StatisticVerification objects
         verifications = []
@@ -409,6 +419,9 @@ def process_article_statistics(
     if any(v.verification_status == VerificationStatus.VERIFIED for v in verifications):
         analysis.stats_verification_status = VerificationStatus.VERIFIED
     analysis.stats_verification_date = datetime.utcnow()
+    analysis.stats_verified = any(
+        v.verification_status == VerificationStatus.VERIFIED for v in verifications
+    )
 
     session.commit()
 

--- a/backend/app/utils/newsletter_token.py
+++ b/backend/app/utils/newsletter_token.py
@@ -1,0 +1,37 @@
+"""
+Signed newsletter links (preferences / unsubscribe). Uses SECRET_KEY from settings.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+
+import jwt
+
+from ..config import settings
+
+_PURPOSES = frozenset({"preferences", "unsubscribe"})
+_DEFAULT_TTL_SECONDS = 90 * 24 * 3600
+
+
+def create_newsletter_token(user_id: int, purpose: str, ttl_seconds: int = _DEFAULT_TTL_SECONDS) -> str:
+    if purpose not in _PURPOSES:
+        raise ValueError(f"Invalid newsletter token purpose: {purpose}")
+    now = int(time.time())
+    payload: Dict[str, Any] = {
+        "uid": user_id,
+        "pur": purpose,
+        "iat": now,
+        "exp": now + ttl_seconds,
+    }
+    return jwt.encode(payload, settings.secret_key, algorithm="HS256")
+
+
+def decode_newsletter_token(token: str) -> Dict[str, Any]:
+    return jwt.decode(
+        token,
+        settings.secret_key,
+        algorithms=["HS256"],
+        options={"require": ["exp", "iat", "uid", "pur"]},
+    )

--- a/backend/tests/fixtures/fact_check/politifact_search_sample.html
+++ b/backend/tests/fixtures/fact_check/politifact_search_sample.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head><title>Search | PolitiFact</title></head>
+<body>
+<div class="search-results">
+  <article>
+    <a href="/factchecks/2024/jan/15/sample-claim/">Sample political claim about inflation numbers</a>
+    <span class="meter-label">Mostly True</span>
+  </article>
+  <a href="/factchecks/2023/dec/01/other/">Another fact check headline here</a>
+</div>
+</body>
+</html>

--- a/backend/tests/fixtures/fact_check/snopes_search_sample.html
+++ b/backend/tests/fixtures/fact_check/snopes_search_sample.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head><title>Search Results - Snopes.com</title></head>
+<body>
+<main>
+  <h2 class="entry-title">
+    <a href="https://www.snopes.com/fact-check/sample-viral-post/">Did something happen? We checked.</a>
+  </h2>
+  <div class="rating">False</div>
+</main>
+</body>
+</html>

--- a/backend/tests/services/test_fact_check_integrator.py
+++ b/backend/tests/services/test_fact_check_integrator.py
@@ -4,6 +4,7 @@ Tests for Fact Check Integrator Service
 import pytest
 from unittest.mock import Mock, patch
 from app.services.fact_check_integrator import FactCheckIntegrator, get_fact_check_integrator
+from app.services.fact_check_scrape.rating_parser import parse_textual_rating_to_status
 
 
 class TestFactCheckIntegrator:
@@ -195,54 +196,40 @@ class TestFactCheckIntegrator:
 
     def test_parse_google_rating_true(self):
         """Test parsing various 'true' ratings"""
-        integrator = FactCheckIntegrator()
-
-        assert integrator._parse_google_rating("True") == "verified"
-        assert integrator._parse_google_rating("Correct") == "verified"
-        assert integrator._parse_google_rating("Accurate") == "verified"
+        assert parse_textual_rating_to_status("True") == "verified"
+        assert parse_textual_rating_to_status("Correct") == "verified"
+        assert parse_textual_rating_to_status("Accurate") == "verified"
 
     def test_parse_google_rating_mostly_true(self):
         """Test parsing 'mostly true' as mixed"""
-        integrator = FactCheckIntegrator()
-
-        assert integrator._parse_google_rating("Mostly True") == "mixed"
-        assert integrator._parse_google_rating("Partially True") == "mixed"
+        assert parse_textual_rating_to_status("Mostly True") == "mixed"
+        assert parse_textual_rating_to_status("Partially True") == "mixed"
 
     def test_parse_google_rating_false(self):
         """Test parsing various 'false' ratings"""
-        integrator = FactCheckIntegrator()
-
-        assert integrator._parse_google_rating("False") == "false"
-        assert integrator._parse_google_rating("Incorrect") == "false"
-        assert integrator._parse_google_rating("Pants on Fire") == "false"
+        assert parse_textual_rating_to_status("False") == "false"
+        assert parse_textual_rating_to_status("Incorrect") == "false"
+        assert parse_textual_rating_to_status("Pants on Fire") == "false"
 
     def test_parse_google_rating_mostly_false(self):
         """Test parsing 'mostly false' as mixed"""
-        integrator = FactCheckIntegrator()
-
-        assert integrator._parse_google_rating("Mostly False") == "mixed"
+        assert parse_textual_rating_to_status("Mostly False") == "mixed"
 
     def test_parse_google_rating_mixed(self):
         """Test parsing mixed ratings"""
-        integrator = FactCheckIntegrator()
-
-        assert integrator._parse_google_rating("Mixture") == "mixed"
-        assert integrator._parse_google_rating("Half True") == "mixed"
-        assert integrator._parse_google_rating("Mixed") == "mixed"
+        assert parse_textual_rating_to_status("Mixture") == "mixed"
+        assert parse_textual_rating_to_status("Half True") == "mixed"
+        assert parse_textual_rating_to_status("Mixed") == "mixed"
 
     def test_parse_google_rating_unproven(self):
         """Test parsing unproven ratings"""
-        integrator = FactCheckIntegrator()
-
-        assert integrator._parse_google_rating("Unproven") == "unverifiable"
-        assert integrator._parse_google_rating("Unclear") == "unverifiable"
-        assert integrator._parse_google_rating("Unsupported") == "unverifiable"
+        assert parse_textual_rating_to_status("Unproven") == "unverifiable"
+        assert parse_textual_rating_to_status("Unclear") == "unverifiable"
+        assert parse_textual_rating_to_status("Unsupported") == "unverifiable"
 
     def test_parse_google_rating_unknown(self):
         """Test parsing unknown rating defaults to unverifiable"""
-        integrator = FactCheckIntegrator()
-
-        assert integrator._parse_google_rating("Unknown Rating") == "unverifiable"
+        assert parse_textual_rating_to_status("Unknown Rating") == "unverifiable"
 
     @patch('app.services.fact_check_integrator.requests.get')
     def test_verify_statistic_uses_google_first(self, mock_get):
@@ -368,3 +355,33 @@ class TestFactCheckIntegrator:
         result = integrator._check_claimbuster("Test")
 
         assert result is None
+
+    @patch("app.services.fact_check_integrator.search_politifact_claim")
+    @patch.object(FactCheckIntegrator, "_check_google_fact_check")
+    def test_verify_statistic_scrape_when_google_low_confidence(
+        self, mock_google, mock_politifact
+    ):
+        """HTML scrapers run when the best API result is below the confidence threshold."""
+        integrator = FactCheckIntegrator()
+        integrator.google_api_key = "test_key"
+        mock_google.return_value = {
+            "fact_check_status": "unverifiable",
+            "fact_check_source": "google_fact_check",
+            "fact_check_url": "",
+            "fact_check_details": "Low signal",
+            "confidence": 0.35,
+        }
+        mock_politifact.return_value = {
+            "fact_check_status": "verified",
+            "fact_check_source": "politifact_scrape",
+            "fact_check_url": "https://www.politifact.com/factchecks/example/",
+            "fact_check_details": "PolitiFact: Example — True",
+            "confidence": 0.85,
+        }
+
+        result = integrator.verify_statistic("Example headline claim")
+
+        assert result is not None
+        assert result["fact_check_source"] == "politifact_scrape"
+        assert result["confidence"] == 0.85
+        mock_politifact.assert_called_once()

--- a/backend/tests/services/test_fact_check_scrape.py
+++ b/backend/tests/services/test_fact_check_scrape.py
@@ -1,0 +1,70 @@
+"""Tests for lightweight fact-check HTML parsers (offline fixtures)."""
+
+from pathlib import Path
+
+import pytest
+
+from app.services.fact_check_scrape.politifact import parse_politifact_search_html, search_politifact_claim
+from app.services.fact_check_scrape.snopes import parse_snopes_search_html, search_snopes_claim
+from app.services.fact_check_scrape.rating_parser import parse_textual_rating_to_status
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures" / "fact_check"
+
+
+def test_parse_textual_rating():
+    assert parse_textual_rating_to_status("Pants on Fire") == "false"
+    assert parse_textual_rating_to_status("Mostly True") == "mixed"
+    assert parse_textual_rating_to_status("True") == "verified"
+    assert parse_textual_rating_to_status("") == "unverifiable"
+
+
+def test_parse_politifact_fixture():
+    html = (FIXTURES / "politifact_search_sample.html").read_text()
+    out = parse_politifact_search_html(html)
+    assert out is not None
+    assert out["fact_check_source"] == "politifact_scrape"
+    assert "/factchecks/" in out["fact_check_url"]
+    assert out["fact_check_status"] == "mixed"  # Mostly True
+    assert out["confidence"] >= 0.5
+
+
+def test_parse_snopes_fixture():
+    html = (FIXTURES / "snopes_search_sample.html").read_text()
+    out = parse_snopes_search_html(html)
+    assert out is not None
+    assert out["fact_check_source"] == "snopes_scrape"
+    assert "/fact-check/" in out["fact_check_url"]
+    assert out["fact_check_status"] == "false"
+
+
+def test_politifact_search_uses_injected_get():
+    html = (FIXTURES / "politifact_search_sample.html").read_text()
+
+    class Resp:
+        status_code = 200
+        content = html.encode()
+
+    def fake_get(url, **kwargs):
+        assert "politifact.com/search" in url
+        return Resp()
+
+    out = search_politifact_claim("test inflation", get=fake_get)
+    assert out is not None
+    assert out["fact_check_source"] == "politifact_scrape"
+
+
+def test_snopes_search_uses_injected_get():
+    html = (FIXTURES / "snopes_search_sample.html").read_text()
+
+    class Resp:
+        status_code = 200
+        content = html.encode()
+
+    def fake_get(url, **kwargs):
+        assert "snopes.com" in url
+        assert "s=" in url
+        return Resp()
+
+    out = search_snopes_claim("viral claim", get=fake_get)
+    assert out is not None
+    assert out["fact_check_source"] == "snopes_scrape"

--- a/backend/tests/utils/test_newsletter_token.py
+++ b/backend/tests/utils/test_newsletter_token.py
@@ -1,0 +1,22 @@
+import pytest
+import jwt
+
+from app.utils.newsletter_token import create_newsletter_token, decode_newsletter_token
+
+
+def test_newsletter_token_round_trip():
+    token = create_newsletter_token(42, "unsubscribe")
+    data = decode_newsletter_token(token)
+    assert data["uid"] == 42
+    assert data["pur"] == "unsubscribe"
+
+
+def test_newsletter_token_wrong_secret():
+    token = create_newsletter_token(1, "preferences")
+    with pytest.raises(jwt.PyJWTError):
+        jwt.decode(
+            token,
+            "wrong-secret-key",
+            algorithms=["HS256"],
+            options={"require": ["exp", "iat", "uid", "pur"]},
+        )

--- a/frontend/src/routes/_app.analytics.tsx
+++ b/frontend/src/routes/_app.analytics.tsx
@@ -12,7 +12,8 @@ import {
   Bar,
   Cell,
 } from "recharts";
-import { api } from "@/lib/api";
+import { ApiError, api } from "@/lib/api";
+import { toast } from "sonner";
 
 export const Route = createFileRoute("/_app/analytics")({
   head: () => ({ meta: [{ title: "Dashboard — Pulse" }] }),
@@ -38,9 +39,17 @@ function AnalyticsPage() {
   const [bias, setBias] = useState<BiasBucket[]>([]);
 
   useEffect(() => {
-    api<Stats>("/analytics/user-stats").then(setStats).catch(() => {});
+    const errMsg = (err: unknown, fallback: string) =>
+      err instanceof ApiError ? err.message : fallback;
+
+    api<Stats>("/analytics/user-stats")
+      .then(setStats)
+      .catch((err) => {
+        toast.error(errMsg(err, "Could not load dashboard stats"));
+      });
+
     api<SentimentApiPoint[]>("/analytics/sentiment-over-time", {
-      query: { days: 30 },
+      query: { days: 30, scope: "user" },
     })
       .then((r) =>
         setSentiment(
@@ -52,9 +61,13 @@ function AnalyticsPage() {
           })),
         ),
       )
-      .catch(() => {});
+      .catch((err) => {
+        toast.error(errMsg(err, "Could not load sentiment over time"));
+        setSentiment([]);
+      });
+
     api<BiasApiPoint[]>("/analytics/bias-distribution", {
-      query: { weeks: 4 },
+      query: { weeks: 4, scope: "user" },
     })
       .then((rows) => {
         if (!rows || rows.length === 0) {
@@ -75,7 +88,10 @@ function AnalyticsPage() {
           { lean: "Right", count: Number((totals.right / rows.length).toFixed(1)) },
         ]);
       })
-      .catch(() => {});
+      .catch((err) => {
+        toast.error(errMsg(err, "Could not load bias distribution"));
+        setBias([]);
+      });
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- add signed newsletter `preferences`/`unsubscribe` links with backend routes and token utility tests
- add optional PolitiFact/Snopes HTML fallback verification plus shared rating parsing and scraping fixtures/tests
- scope analytics sentiment/bias data to user subscriptions/topics by default, improve dashboard error toasts, and wire post-analysis stats verification updates

## Test plan
- [x] Existing backend tests updated for fact-check rating parsing
- [x] Added unit tests for newsletter token round-trip/validation
- [x] Added fixture-driven parser tests for PolitiFact and Snopes HTML search parsing
- [ ] Run full backend test suite in CI
- [ ] Verify analytics dashboard behavior manually with user-scoped and empty-preference accounts

Made with [Cursor](https://cursor.com)