### PR TITLE
feat(admin): add job control, logs, and re-analysis actions

### DIFF
--- a/backend/app/jobs/scheduler.py
+++ b/backend/app/jobs/scheduler.py
@@ -23,6 +23,7 @@ from ..jobs.tasks import (
 )
 from ..config import settings
 import logging
+from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -161,3 +162,45 @@ def get_job_status():
         "status": "running",
         "jobs": jobs
     }
+
+
+def list_scheduler_jobs():
+    """Return scheduler job metadata including pause state."""
+    if not scheduler.running:
+        return {"status": "stopped", "jobs": []}
+
+    jobs = []
+    for job in scheduler.get_jobs():
+        jobs.append({
+            "id": job.id,
+            "name": job.name,
+            "next_run": str(job.next_run_time) if job.next_run_time else None,
+            "trigger": str(job.trigger),
+            "is_paused": job.next_run_time is None,
+        })
+    return {"status": "running", "jobs": jobs}
+
+
+def control_scheduler_job(job_id: str, action: str):
+    """
+    Control scheduler jobs. Supported actions: pause, resume, stop.
+    `stop` is an alias of `pause` for schedule control.
+    """
+    if not scheduler.running:
+        return {"success": False, "error": "Scheduler is not running"}
+
+    job = scheduler.get_job(job_id)
+    if not job:
+        return {"success": False, "error": f"Job '{job_id}' not found"}
+
+    if action in {"pause", "stop"}:
+        scheduler.pause_job(job_id)
+        return {"success": True, "job_id": job_id, "action": action, "status": "paused"}
+    if action == "resume":
+        scheduler.resume_job(job_id)
+        return {"success": True, "job_id": job_id, "action": action, "status": "scheduled"}
+    if action == "trigger":
+        scheduler.modify_job(job_id, next_run_time=datetime.utcnow())
+        return {"success": True, "job_id": job_id, "action": action, "status": "trigger_queued"}
+
+    return {"success": False, "error": f"Unsupported action '{action}'"}

--- a/backend/app/jobs/tasks.py
+++ b/backend/app/jobs/tasks.py
@@ -299,6 +299,77 @@ def analyze_job(session: Session = None, chain_processing: bool = False):
         return {"success": False, "error": str(e)}
 
 
+@track_job_execution(job_id="reanalyze_unanalyzed_failed", job_name="Re-analyze Unanalyzed/Failed Articles")
+def reanalyze_unanalyzed_failed_job(session: Session = None):
+    """
+    Admin recovery job: analyze all articles that:
+    - have content_text
+    - have no ArticleAnalysis row
+    - are either COMPLETED or FAILED processing_status
+    """
+    try:
+        logger.info("=" * 60)
+        logger.info("Starting re-analysis job for unanalyzed/failed articles")
+        logger.info("=" * 60)
+
+        from ..services.ai_analyzer import analyze_articles_batch, get_unanalyzed_article_count
+
+        total_analyzed = 0
+        batch_num = 0
+
+        if session is None:
+            with Session(engine) as temp_session:
+                initial_count = get_unanalyzed_article_count(
+                    temp_session,
+                    include_failed_status=True,
+                )
+        else:
+            initial_count = get_unanalyzed_article_count(
+                session,
+                include_failed_status=True,
+            )
+
+        logger.info("Found %s unanalyzed/failed analysis candidates", initial_count)
+
+        if session is None:
+            with Session(engine) as run_session:
+                while True:
+                    batch_num += 1
+                    count = analyze_articles_batch(
+                        run_session,
+                        batch_size=5,
+                        include_failed_status=True,
+                    )
+                    total_analyzed += count
+                    if count == 0:
+                        break
+                    time.sleep(1)
+        else:
+            while True:
+                batch_num += 1
+                count = analyze_articles_batch(
+                    session,
+                    batch_size=5,
+                    include_failed_status=True,
+                )
+                total_analyzed += count
+                if count == 0:
+                    break
+                time.sleep(1)
+
+        logger.info(
+            "Re-analysis completed: %s/%s articles analyzed across %s batches",
+            total_analyzed,
+            initial_count,
+            batch_num,
+        )
+        logger.info("=" * 60)
+        return {"success": True, "articles_analyzed": total_analyzed}
+    except Exception as e:
+        logger.error("Re-analysis job failed: %s", e, exc_info=True)
+        return {"success": False, "error": str(e)}
+
+
 @track_job_execution(job_id="framework_mapping", job_name="Framework Mapping & Discovery")
 def framework_job(session: Session = None):
     """

--- a/backend/app/routes/admin_panel.py
+++ b/backend/app/routes/admin_panel.py
@@ -17,6 +17,7 @@ from ..models import (
 )
 from ..database import get_session
 from ..utils.admin_auth import get_admin_user, log_admin_action
+from ..jobs.scheduler import list_scheduler_jobs, control_scheduler_job
 
 logger = logging.getLogger(__name__)
 
@@ -239,6 +240,87 @@ def get_job_history(
     }
 
 
+@router.get("/jobs/history/{execution_id}")
+def get_job_execution_log(
+    execution_id: int,
+    admin_user: User = Depends(get_admin_user),
+    session: Session = Depends(get_session),
+) -> Dict[str, Any]:
+    """Get detailed log payload for a single job execution."""
+    job = session.get(JobExecutionHistory, execution_id)
+    if not job:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Job execution not found",
+        )
+
+    return {
+        "id": job.id,
+        "job_id": job.job_id,
+        "job_name": job.job_name,
+        "status": job.status,
+        "started_at": job.started_at.isoformat(),
+        "completed_at": job.completed_at.isoformat() if job.completed_at else None,
+        "duration_seconds": job.duration_seconds,
+        "items_processed": job.items_processed,
+        "api_calls_made": job.api_calls_made,
+        "tokens_used": job.tokens_used,
+        "triggered_by": job.triggered_by,
+        "triggered_by_user_id": job.triggered_by_user_id,
+        "error_message": job.error_message,
+        "result_data": job.result_data,
+    }
+
+
+@router.get("/jobs/scheduler")
+def get_scheduler_jobs(
+    admin_user: User = Depends(get_admin_user),
+) -> Dict[str, Any]:
+    """Get scheduler definitions with pause/schedule state."""
+    return list_scheduler_jobs()
+
+
+@router.post("/jobs/control/{job_id}")
+def control_job_schedule(
+    job_id: str,
+    action: str,
+    request: Request,
+    admin_user: User = Depends(get_admin_user),
+    session: Session = Depends(get_session),
+) -> Dict[str, Any]:
+    """
+    Control a scheduler job:
+    - pause: temporarily disable schedule
+    - resume: re-enable schedule
+    - stop: alias of pause
+    - trigger: queue immediate run
+    """
+    action = action.lower().strip()
+    if action not in {"pause", "resume", "stop", "trigger"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid action. Supported actions: pause, resume, stop, trigger",
+        )
+
+    result = control_scheduler_job(job_id, action)
+    if not result.get("success"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=result.get("error", "Failed to control job"),
+        )
+
+    log_admin_action(
+        admin_user=admin_user,
+        action_type=f"control_job_{action}",
+        resource_type="scheduler_job",
+        resource_id=job_id,
+        new_value=str(result),
+        session=session,
+        request=request,
+    )
+    return result
+
+
 @router.post("/jobs/trigger/{job_id}")
 def trigger_job(
     job_id: str,
@@ -253,6 +335,7 @@ def trigger_job(
         - scrape_rss
         - extract_articles
         - analyze_articles
+        - reanalyze_unanalyzed_failed
         - update_frameworks
         - verify_statistics
         - cluster_articles
@@ -264,7 +347,7 @@ def trigger_job(
     from ..jobs.tasks import (
         scrape_job, extract_job, analyze_job, framework_job,
         statistics_verification_job, article_clustering_job,
-        context_generation_job, newsletter_job
+        context_generation_job, newsletter_job, reanalyze_unanalyzed_failed_job
     )
 
     # Map job IDs to functions
@@ -272,6 +355,11 @@ def trigger_job(
         "scrape_rss": ("scrape_job", scrape_job, "Scrape RSS Feeds"),
         "extract_articles": ("extract_job", extract_job, "Extract Article Content"),
         "analyze_articles": ("analyze_job", analyze_job, "AI Article Analysis"),
+        "reanalyze_unanalyzed_failed": (
+            "reanalyze_unanalyzed_failed_job",
+            reanalyze_unanalyzed_failed_job,
+            "Re-analyze Unanalyzed/Failed Articles",
+        ),
         "update_frameworks": ("framework_job", framework_job, "Update Frameworks"),
         "verify_statistics": ("statistics_verification_job", statistics_verification_job, "Verify Statistics"),
         "cluster_articles": ("article_clustering_job", article_clustering_job, "Cluster Articles"),

--- a/backend/app/services/ai_analyzer.py
+++ b/backend/app/services/ai_analyzer.py
@@ -4,6 +4,7 @@ Generates summaries, sentiment analysis, bias detection, and extracts key statis
 """
 
 from sqlmodel import Session, select
+from sqlalchemy import or_
 from ..models import Article, ArticleAnalysis, ProcessingStatus, PoliticalLean, Topic, ArticleTopicLink
 from ..database import engine
 from ..services.statistics_verifier import process_article_statistics
@@ -15,7 +16,11 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def analyze_articles_batch(session: Session, batch_size: int = 5) -> int:
+def analyze_articles_batch(
+    session: Session,
+    batch_size: int = 5,
+    include_failed_status: bool = False,
+) -> int:
     """
     Analyze a batch of articles using Claude API.
     Processes articles that have been extracted but not yet analyzed.
@@ -33,14 +38,21 @@ def analyze_articles_batch(session: Session, batch_size: int = 5) -> int:
 
     analyzed_count = 0
 
-    # Get completed articles that haven't been analyzed yet
+    # Get extracted articles that haven't been analyzed yet.
+    # Optionally include FAILED rows to recover analysis candidates that still have content.
+    status_filter = (
+        or_(
+            Article.processing_status == ProcessingStatus.COMPLETED,
+            Article.processing_status == ProcessingStatus.FAILED,
+        )
+        if include_failed_status
+        else (Article.processing_status == ProcessingStatus.COMPLETED)
+    )
     articles_to_analyze = session.exec(
         select(Article)
-        .where(Article.processing_status == ProcessingStatus.COMPLETED)
+        .where(status_filter)
         .where(Article.content_text.isnot(None))
-        .where(~Article.id.in_(
-            select(ArticleAnalysis.article_id)
-        ))
+        .where(~Article.id.in_(select(ArticleAnalysis.article_id)))
         .limit(batch_size)
     ).all()
 
@@ -180,15 +192,24 @@ def get_article_analysis(article_id: int, session: Session) -> Optional[ArticleA
     ).first()
 
 
-def get_unanalyzed_article_count(session: Session) -> int:
+def get_unanalyzed_article_count(
+    session: Session,
+    include_failed_status: bool = False,
+) -> int:
     """Get count of extracted articles that haven't been analyzed yet"""
+    status_filter = (
+        or_(
+            Article.processing_status == ProcessingStatus.COMPLETED,
+            Article.processing_status == ProcessingStatus.FAILED,
+        )
+        if include_failed_status
+        else (Article.processing_status == ProcessingStatus.COMPLETED)
+    )
     return session.exec(
         select(Article)
-        .where(Article.processing_status == ProcessingStatus.COMPLETED)
+        .where(status_filter)
         .where(Article.content_text.isnot(None))
-        .where(~Article.id.in_(
-            select(ArticleAnalysis.article_id)
-        ))
+        .where(~Article.id.in_(select(ArticleAnalysis.article_id)))
     ).all().__len__()
 
 

--- a/backend/tests/routes/test_admin_panel.py
+++ b/backend/tests/routes/test_admin_panel.py
@@ -178,6 +178,44 @@ class TestJobManagement:
         data = response.json()
         assert data["limit"] == 5
 
+    def test_get_job_execution_log(self, client: TestClient, admin_headers: dict, session: Session):
+        """Test getting a single job execution log entry."""
+        job = JobExecutionHistory(
+            job_id="extract_articles",
+            job_name="Extract Article Content",
+            started_at=datetime.utcnow(),
+            status="failed",
+            error_message="Sample failure",
+            result_data="{'success': False}",
+            triggered_by="admin",
+        )
+        session.add(job)
+        session.commit()
+        session.refresh(job)
+
+        response = client.get(f"/admin-panel/jobs/history/{job.id}", headers=admin_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == job.id
+        assert data["job_id"] == "extract_articles"
+        assert data["error_message"] == "Sample failure"
+
+    def test_get_scheduler_jobs(self, client: TestClient, admin_headers: dict):
+        """Test scheduler job listing endpoint."""
+        response = client.get("/admin-panel/jobs/scheduler", headers=admin_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert "status" in data
+        assert "jobs" in data
+
+    def test_control_scheduler_job_invalid_action(self, client: TestClient, admin_headers: dict):
+        """Test scheduler control validation for unsupported action."""
+        response = client.post(
+            "/admin-panel/jobs/control/scrape_rss?action=invalid",
+            headers=admin_headers,
+        )
+        assert response.status_code == 400
+
     def test_trigger_job(self, client: TestClient, admin_headers: dict, session: Session):
         """Test manually triggering a job."""
         response = client.post(
@@ -190,6 +228,16 @@ class TestJobManagement:
         assert data["job_id"] == "scrape_rss"
         assert "result" in data
         assert "execution_id" in data
+
+    def test_trigger_reanalyze_unanalyzed_failed_job(self, client: TestClient, admin_headers: dict):
+        """Test manual trigger for re-analysis recovery job."""
+        response = client.post(
+            "/admin-panel/jobs/trigger/reanalyze_unanalyzed_failed",
+            headers=admin_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["job_id"] == "reanalyze_unanalyzed_failed"
 
 
 class TestUserManagement:

--- a/frontend/src/routes/_app.admin.tsx
+++ b/frontend/src/routes/_app.admin.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { Link, createFileRoute } from "@tanstack/react-router";
 import { useEffect, useMemo, useState } from "react";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
@@ -25,10 +25,24 @@ type AdminJob = {
   duration_seconds?: number;
   items_processed?: number;
   error_message?: string | null;
+  result_data?: string | null;
 };
 
 type AdminJobsResponse = {
   jobs: AdminJob[];
+};
+
+type SchedulerJob = {
+  id: string;
+  name: string;
+  next_run?: string | null;
+  trigger: string;
+  is_paused: boolean;
+};
+
+type SchedulerJobsResponse = {
+  status: string;
+  jobs: SchedulerJob[];
 };
 
 type AdminUser = {
@@ -92,10 +106,12 @@ const JOB_TRIGGER_IDS = [
   "cluster_articles",
   "generate_context",
   "send_newsletters",
+  "reanalyze_unanalyzed_failed",
 ] as const;
 
 export const Route = createFileRoute("/_app/admin")<{
   tab?: AdminTab;
+  logId?: number;
 }>({
   validateSearch: (search) => {
     const tab = search.tab;
@@ -109,7 +125,13 @@ export const Route = createFileRoute("/_app/admin")<{
     ) {
       return { tab };
     }
-    return { tab: "dashboard" as AdminTab };
+    const logId =
+      typeof search.logId === "number"
+        ? search.logId
+        : typeof search.logId === "string" && search.logId.trim() !== ""
+          ? Number.parseInt(search.logId, 10)
+          : undefined;
+    return { tab: "dashboard" as AdminTab, logId: Number.isNaN(logId) ? undefined : logId };
   },
   head: () => ({ meta: [{ title: "Admin Dashboard — Pulse" }] }),
   component: AdminPage,
@@ -120,8 +142,10 @@ function AdminPage() {
   const navigate = Route.useNavigate();
   const { user } = useAuth();
   const tab = (search.tab ?? "dashboard") as AdminTab;
+  const selectedLogId = search.logId;
   const [dashboard, setDashboard] = useState<AdminDashboardResponse | null>(null);
   const [jobs, setJobs] = useState<AdminJob[]>([]);
+  const [schedulerJobs, setSchedulerJobs] = useState<SchedulerJob[]>([]);
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [sources, setSources] = useState<AdminSource[]>([]);
   const [articles, setArticles] = useState<AdminArticle[]>([]);
@@ -136,23 +160,27 @@ function AdminPage() {
       tab === "dashboard"
         ? api<AdminDashboardResponse>("/admin-panel/dashboard").then(setDashboard)
         : tab === "jobs"
-          ? api<AdminJobsResponse>("/admin-panel/jobs/history", { query: { limit: 30 } }).then((r) =>
-              setJobs(r.jobs || []),
-            )
+          ? Promise.all([
+              api<AdminJobsResponse>("/admin-panel/jobs/history", { query: { limit: 30 } }),
+              api<SchedulerJobsResponse>("/admin-panel/jobs/scheduler"),
+            ]).then(([history, scheduler]) => {
+              setJobs(history.jobs || []);
+              setSchedulerJobs(scheduler.jobs || []);
+            })
           : tab === "users"
-            ? api<AdminUsersResponse>("/admin-panel/users", { query: { page_size: 50 } }).then((r) =>
-                setUsers(r.users || []),
+            ? api<AdminUsersResponse>("/admin-panel/users", { query: { page_size: 50 } }).then(
+                (r) => setUsers(r.users || []),
               )
             : tab === "sources"
               ? api<AdminSourcesResponse>("/admin-panel/sources", {
                   query: { page_size: 50, active_only: false },
                 }).then((r) => setSources(r.sources || []))
               : tab === "articles"
-                ? api<AdminArticlesResponse>("/admin-panel/articles", { query: { page_size: 50 } }).then(
-                    (r) => setArticles(r.articles || []),
-                  )
-                : api<AdminAuditResponse>("/admin-panel/audit", { query: { page_size: 50 } }).then((r) =>
-                    setAuditLogs(r.audit_logs || []),
+                ? api<AdminArticlesResponse>("/admin-panel/articles", {
+                    query: { page_size: 50 },
+                  }).then((r) => setArticles(r.articles || []))
+                : api<AdminAuditResponse>("/admin-panel/audit", { query: { page_size: 50 } }).then(
+                    (r) => setAuditLogs(r.audit_logs || []),
                   );
 
     req
@@ -179,15 +207,40 @@ function AdminPage() {
     [],
   );
 
+  async function refreshJobs() {
+    const [history, scheduler] = await Promise.all([
+      api<AdminJobsResponse>("/admin-panel/jobs/history", { query: { limit: 30 } }),
+      api<SchedulerJobsResponse>("/admin-panel/jobs/scheduler"),
+    ]);
+    setJobs(history.jobs || []);
+    setSchedulerJobs(scheduler.jobs || []);
+  }
+
   async function triggerJob(jobId: (typeof JOB_TRIGGER_IDS)[number]) {
     try {
       await api(`/admin-panel/jobs/trigger/${jobId}`, { method: "POST" });
       if (tab === "jobs") {
-        const r = await api<AdminJobsResponse>("/admin-panel/jobs/history", { query: { limit: 30 } });
-        setJobs(r.jobs || []);
+        await refreshJobs();
       }
     } catch (err) {
       setError(err instanceof ApiError ? err.message : "Could not trigger job");
+    }
+  }
+
+  async function controlSchedulerJob(
+    jobId: string,
+    action: "pause" | "resume" | "stop" | "trigger",
+  ) {
+    try {
+      await api(`/admin-panel/jobs/control/${jobId}`, {
+        method: "POST",
+        query: { action },
+      });
+      if (tab === "jobs") {
+        await refreshJobs();
+      }
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Could not control scheduler job");
     }
   }
 
@@ -197,7 +250,9 @@ function AdminPage() {
         method: "PUT",
         query: { is_admin: !target.is_admin },
       });
-      setUsers((prev) => prev.map((u) => (u.id === target.id ? { ...u, is_admin: !u.is_admin } : u)));
+      setUsers((prev) =>
+        prev.map((u) => (u.id === target.id ? { ...u, is_admin: !u.is_admin } : u)),
+      );
     } catch (err) {
       setError(err instanceof ApiError ? err.message : "Could not update admin role");
     }
@@ -227,7 +282,9 @@ function AdminPage() {
   return (
     <div className="max-w-[1100px] mx-auto px-6 py-12">
       <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-3">Operations</p>
-      <h1 className="font-serif text-4xl md:text-5xl font-medium tracking-tight">Admin dashboard</h1>
+      <h1 className="font-serif text-4xl md:text-5xl font-medium tracking-tight">
+        Admin dashboard
+      </h1>
       {user?.email && <p className="mt-2 text-muted-foreground">{user.email}</p>}
 
       <div className="mt-8 flex flex-wrap gap-2">
@@ -261,7 +318,10 @@ function AdminPage() {
                 <Stat label="Users" value={dashboard?.system_stats?.users?.total ?? 0} />
                 <Stat label="Admins" value={dashboard?.system_stats?.users?.admins ?? 0} />
                 <Stat label="Articles" value={dashboard?.system_stats?.articles?.total ?? 0} />
-                <Stat label="Failed jobs (24h)" value={dashboard?.error_summary?.failed_jobs_24h ?? 0} />
+                <Stat
+                  label="Failed jobs (24h)"
+                  value={dashboard?.error_summary?.failed_jobs_24h ?? 0}
+                />
               </div>
 
               <section className="mt-10 border border-border rounded-lg p-5 bg-card">
@@ -270,10 +330,20 @@ function AdminPage() {
                   {(dashboard?.recent_jobs ?? []).slice(0, 8).map((job) => (
                     <div key={job.id} className="py-3 flex items-center justify-between gap-3">
                       <div>
-                        <p className="font-medium">{job.job_name}</p>
-                        <p className="text-xs text-muted-foreground">{new Date(job.started_at).toLocaleString()}</p>
+                        <Link
+                          to="/admin"
+                          search={{ tab: "jobs", logId: job.id }}
+                          className="font-medium hover:underline"
+                        >
+                          {job.job_name}
+                        </Link>
+                        <p className="text-xs text-muted-foreground">
+                          {new Date(job.started_at).toLocaleString()}
+                        </p>
                       </div>
-                      <span className="text-xs uppercase tracking-wider text-muted-foreground">{job.status}</span>
+                      <span className="text-xs uppercase tracking-wider text-muted-foreground">
+                        {job.status}
+                      </span>
                     </div>
                   ))}
                   {(dashboard?.recent_jobs?.length ?? 0) === 0 && (
@@ -298,20 +368,103 @@ function AdminPage() {
                   </button>
                 ))}
               </div>
+              <h3 className="mt-8 text-sm uppercase tracking-wider text-muted-foreground">
+                Scheduler controls
+              </h3>
+              <div className="mt-3 divide-y divide-border">
+                {schedulerJobs.map((job) => (
+                  <div key={job.id} className="py-3 flex items-center justify-between gap-3">
+                    <div>
+                      <p className="font-medium">{job.name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {job.id} • {job.is_paused ? "paused" : "scheduled"}
+                        {job.next_run ? ` • next ${new Date(job.next_run).toLocaleString()}` : ""}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => controlSchedulerJob(job.id, "trigger")}
+                        className="px-3 py-1.5 rounded-md border border-border text-sm hover:bg-accent"
+                      >
+                        Trigger
+                      </button>
+                      {job.is_paused ? (
+                        <button
+                          onClick={() => controlSchedulerJob(job.id, "resume")}
+                          className="px-3 py-1.5 rounded-md border border-border text-sm hover:bg-accent"
+                        >
+                          Resume
+                        </button>
+                      ) : (
+                        <button
+                          onClick={() => controlSchedulerJob(job.id, "pause")}
+                          className="px-3 py-1.5 rounded-md border border-border text-sm hover:bg-accent"
+                        >
+                          Pause
+                        </button>
+                      )}
+                      <button
+                        onClick={() => controlSchedulerJob(job.id, "stop")}
+                        className="px-3 py-1.5 rounded-md border border-border text-sm hover:bg-accent"
+                      >
+                        Stop
+                      </button>
+                    </div>
+                  </div>
+                ))}
+                {schedulerJobs.length === 0 && (
+                  <p className="py-3 text-sm text-muted-foreground">No scheduler jobs found.</p>
+                )}
+              </div>
               <div className="mt-6 divide-y divide-border">
                 {jobs.map((job) => (
                   <div key={job.id} className="py-3 flex items-center justify-between gap-3">
                     <div>
-                      <p className="font-medium">{job.job_name}</p>
+                      <Link
+                        to="/admin"
+                        search={{ tab: "jobs", logId: job.id }}
+                        className="font-medium hover:underline"
+                      >
+                        {job.job_name}
+                      </Link>
                       <p className="text-xs text-muted-foreground">
-                        {new Date(job.started_at).toLocaleString()} {job.duration_seconds ? `• ${job.duration_seconds.toFixed(1)}s` : ""}
+                        {new Date(job.started_at).toLocaleString()}{" "}
+                        {job.duration_seconds ? `• ${job.duration_seconds.toFixed(1)}s` : ""}
                       </p>
                     </div>
-                    <span className="text-xs uppercase tracking-wider text-muted-foreground">{job.status}</span>
+                    <span className="text-xs uppercase tracking-wider text-muted-foreground">
+                      {job.status}
+                    </span>
                   </div>
                 ))}
-                {jobs.length === 0 && <p className="py-3 text-sm text-muted-foreground">No job history found.</p>}
+                {jobs.length === 0 && (
+                  <p className="py-3 text-sm text-muted-foreground">No job history found.</p>
+                )}
               </div>
+              {selectedLogId ? (
+                <div className="mt-6 border border-border rounded-lg p-4 bg-background/50">
+                  {jobs
+                    .filter((job) => job.id === selectedLogId)
+                    .map((job) => (
+                      <div key={job.id}>
+                        <p className="font-medium">Execution log: {job.job_name}</p>
+                        <p className="mt-2 text-xs text-muted-foreground">
+                          status {job.status} • started {new Date(job.started_at).toLocaleString()}
+                        </p>
+                        {job.error_message && (
+                          <pre className="mt-3 text-xs whitespace-pre-wrap rounded-md border border-border p-3 bg-card">
+                            {job.error_message}
+                          </pre>
+                        )}
+                        {job.result_data && (
+                          <pre className="mt-3 text-xs whitespace-pre-wrap rounded-md border border-border p-3 bg-card">
+                            {job.result_data}
+                          </pre>
+                        )}
+                      </div>
+                    ))}
+                </div>
+              ) : null}
             </section>
           )}
 
@@ -333,7 +486,9 @@ function AdminPage() {
                     </button>
                   </div>
                 ))}
-                {users.length === 0 && <p className="py-3 text-sm text-muted-foreground">No users found.</p>}
+                {users.length === 0 && (
+                  <p className="py-3 text-sm text-muted-foreground">No users found.</p>
+                )}
               </div>
             </section>
           )}
@@ -347,7 +502,8 @@ function AdminPage() {
                     <div>
                       <p className="font-medium">{s.name}</p>
                       <p className="text-xs text-muted-foreground">
-                        {s.organizational_bias || "unrated"} • trust {s.trust_score ?? 0} • {s.article_count} articles
+                        {s.organizational_bias || "unrated"} • trust {s.trust_score ?? 0} •{" "}
+                        {s.article_count} articles
                       </p>
                     </div>
                     <button
@@ -359,7 +515,9 @@ function AdminPage() {
                     </button>
                   </div>
                 ))}
-                {sources.length === 0 && <p className="py-3 text-sm text-muted-foreground">No sources found.</p>}
+                {sources.length === 0 && (
+                  <p className="py-3 text-sm text-muted-foreground">No sources found.</p>
+                )}
               </div>
             </section>
           )}
@@ -371,9 +529,16 @@ function AdminPage() {
                 {articles.map((a) => (
                   <div key={a.id} className="py-3 flex items-center justify-between gap-3">
                     <div className="min-w-0">
-                      <p className="font-medium truncate">{a.title}</p>
+                      <Link
+                        to="/article/$id"
+                        params={{ id: String(a.id) }}
+                        className="font-medium truncate hover:underline block"
+                      >
+                        {a.title}
+                      </Link>
                       <p className="text-xs text-muted-foreground">
-                        {a.processing_status} • source {a.source_id} • {new Date(a.scraped_at).toLocaleString()}
+                        {a.processing_status} • source {a.source_id} •{" "}
+                        {new Date(a.scraped_at).toLocaleString()}
                       </p>
                     </div>
                     <button
@@ -384,7 +549,9 @@ function AdminPage() {
                     </button>
                   </div>
                 ))}
-                {articles.length === 0 && <p className="py-3 text-sm text-muted-foreground">No articles found.</p>}
+                {articles.length === 0 && (
+                  <p className="py-3 text-sm text-muted-foreground">No articles found.</p>
+                )}
               </div>
             </section>
           )}
@@ -404,7 +571,9 @@ function AdminPage() {
                     </p>
                   </div>
                 ))}
-                {auditLogs.length === 0 && <p className="py-3 text-sm text-muted-foreground">No audit events found.</p>}
+                {auditLogs.length === 0 && (
+                  <p className="py-3 text-sm text-muted-foreground">No audit events found.</p>
+                )}
               </div>
             </section>
           )}

--- a/llm-instructions.md
+++ b/llm-instructions.md
@@ -544,6 +544,13 @@ For any agent modifying frontend build/deploy behavior, treat this as required p
 - Admin UI route is **`/admin`** (`frontend/src/routes/_app.admin.tsx`).
 - Show admin nav only for users with `user.is_admin === true` (with temporary fallback for `cade.richard@gmail.com` while role data is reconciled).
 - Backend admin dashboard data source is `GET /admin-panel/dashboard`; if this endpoint contract changes, update `frontend/src/routes/_app.admin.tsx` in the same PR.
+- Job operations in admin panel now include:
+  - `GET /admin-panel/jobs/scheduler` (scheduled job state)
+  - `POST /admin-panel/jobs/control/{job_id}?action=pause|resume|stop|trigger`
+  - `GET /admin-panel/jobs/history/{execution_id}` (single execution log payload)
+  - `POST /admin-panel/jobs/trigger/reanalyze_unanalyzed_failed` (manual recovery)
+- Admin jobs list entries should deep-link to `/admin?tab=jobs&logId=<execution_id>` and display execution `error_message` / `result_data`.
+- Admin article list titles should link to `/article/$id` for direct inspection.
 - Before declaring dashboard/admin fixes complete, verify all of:
   - `/analytics` loads
   - `/dashboard` redirects to `/analytics`


### PR DESCRIPTION
## Summary
- add admin scheduler control endpoints (pause/resume/stop/trigger) and scheduler state listing
- add per-execution job log endpoint and wire admin jobs list entries to log views
- add admin trigger for re-analyzing unanalyzed/failed articles and link admin article list rows to article detail pages

## Test plan
- [x] Frontend lint for `frontend/src/routes/_app.admin.tsx`
- [x] Added backend admin-panel route tests for new job endpoints
- [ ] Run full backend test suite in CI/runtime-matching Python environment
- [ ] Manually verify `/admin` Jobs tab controls and log deep-link behavior

Made with [Cursor](https://cursor.com)