### PR TITLE
feat(frontend): complete web feed polish parity pass

### DIFF
--- a/frontend/src/components/ArticleCard.tsx
+++ b/frontend/src/components/ArticleCard.tsx
@@ -2,7 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { Star } from "lucide-react";
 import type { Article } from "@/lib/types";
 import { timeAgo, cn } from "@/lib/utils";
-import { LeanMeter, SentimentDot, VerifiedBadge, FrameworkChip } from "./Signals";
+import { SentimentDot, VerifiedBadge, LeanPill, FrameworkCue } from "./Signals";
 
 export function ArticleCard({
   article,
@@ -17,7 +17,7 @@ export function ArticleCard({
   return (
     <article
       className={cn(
-        "grid grid-cols-1 md:grid-cols-[12rem_1fr] gap-6 md:gap-12",
+        "grid grid-cols-1 md:grid-cols-[11rem_1fr] gap-5 md:gap-10 motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out motion-safe:hover:-translate-y-0.5",
         compact ? "pt-8 border-t border-border" : "pt-8 border-t border-border",
       )}
     >
@@ -37,17 +37,17 @@ export function ArticleCard({
         </time>
       </div>
 
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3.5">
         <div className="flex items-start justify-between gap-6">
           <Link
             to="/article/$id"
             params={{ id: String(article.id) }}
-            className="group"
+            className="group focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
           >
             <h2
               className={cn(
                 "font-serif font-medium tracking-tight text-foreground text-balance leading-[1.1] group-hover:underline decoration-1 underline-offset-4",
-                compact ? "text-2xl md:text-[1.6rem]" : "text-3xl md:text-4xl",
+                compact ? "text-[1.6rem] md:text-[1.8rem]" : "text-2xl md:text-3xl",
               )}
             >
               {article.title}
@@ -57,15 +57,16 @@ export function ArticleCard({
             <button
               onClick={() => onToggleFavorite(article)}
               aria-label={article.is_favorited ? "Remove from saved" : "Save article"}
+              aria-pressed={!!article.is_favorited}
               className={cn(
-                "shrink-0 mt-1 transition-colors",
+                "shrink-0 mt-1 inline-flex items-center justify-center size-9 rounded-full border transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                 article.is_favorited
-                  ? "text-foreground"
-                  : "text-muted-foreground/50 hover:text-foreground",
+                  ? "text-foreground border-border bg-accent/50"
+                  : "text-muted-foreground/70 border-border hover:text-foreground hover:bg-accent/50",
               )}
             >
               <Star
-                className="size-5"
+                className="size-[18px]"
                 fill={article.is_favorited ? "currentColor" : "none"}
                 strokeWidth={1.5}
               />
@@ -74,18 +75,16 @@ export function ArticleCard({
         </div>
 
         {article.summary && (
-          <p className="text-base md:text-lg text-muted-foreground max-w-[65ch] leading-relaxed text-pretty">
+          <p className="text-base text-muted-foreground max-w-[65ch] leading-relaxed text-pretty line-clamp-3">
             {article.summary}
           </p>
         )}
 
-        <div className="flex flex-wrap items-center gap-x-5 gap-y-3 mt-2 pt-4 border-t border-border">
+        <div className="flex flex-wrap items-center gap-x-2.5 gap-y-2.5 mt-2 pt-3 border-t border-border">
           {article.has_verified_stats && <VerifiedBadge />}
+          <LeanPill score={article.political_lean} />
           <SentimentDot sentiment={article.sentiment} />
-          <LeanMeter score={article.political_lean} />
-          {article.frameworks?.slice(0, 2).map((fp, i) => (
-            <FrameworkChip key={i}>{fp.framework?.name}</FrameworkChip>
-          ))}
+          <FrameworkCue placement={article.frameworks?.[0]} className="min-w-0" />
         </div>
       </div>
     </article>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,8 +1,7 @@
 import { Link } from "@tanstack/react-router";
 
 const DOCS_URL =
-  (import.meta.env.VITE_DOCUMENTATION_URL as string | undefined) ||
-  "https://docs.pulsenews.app";
+  (import.meta.env.VITE_DOCUMENTATION_URL as string | undefined) || "https://docs.pulsenews.app";
 
 export function Footer() {
   return (

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -5,10 +5,14 @@ import { useTheme } from "@/lib/theme";
 import { cn } from "@/lib/utils";
 
 const navLinks = [
-  { to: "/feed", label: "Feed" },
+  {
+    to: "/feed",
+    label: "Feed",
+    search: { page: 1, q: "", topic: "", lean: "", sort: "newest", fav: false },
+  },
   { to: "/analyze", label: "Analyze" },
   { to: "/insights", label: "Insights" },
-  { to: "/preferences", label: "Preferences" },
+  { to: "/preferences", label: "Preferences", search: { tab: "topics" } },
   { to: "/analytics", label: "Dashboard" },
 ] as const;
 
@@ -32,6 +36,7 @@ export function Header() {
                 <Link
                   key={l.to}
                   to={l.to}
+                  {...("search" in l ? { search: l.search } : {})}
                   className={cn(
                     "pb-1 border-b transition-colors",
                     active
@@ -46,6 +51,7 @@ export function Header() {
             {hasAdminAccess && (
               <Link
                 to="/admin"
+                search={{ tab: "dashboard" }}
                 className={cn(
                   "pb-1 border-b transition-colors",
                   path === "/admin" || path.startsWith("/admin/")

--- a/frontend/src/components/Signals.tsx
+++ b/frontend/src/components/Signals.tsx
@@ -1,5 +1,8 @@
 import { cn } from "@/lib/utils";
 import { leanColorVar, leanLabel } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import type { FrameworkPlacement } from "@/lib/types";
+import { Minus, TrendingDown, TrendingUp } from "lucide-react";
 
 export function LeanMeter({
   score,
@@ -14,8 +17,11 @@ export function LeanMeter({
   const left = ((s + 1) / 2) * 100;
   const color = leanColorVar(score);
   return (
-    <div className={cn("flex items-center gap-2", className)} title={`Political lean: ${leanLabel(score)}`}>
-      <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-medium">L</span>
+    <div
+      className={cn("flex items-center gap-2", className)}
+      title={`Political lean: ${leanLabel(score)}`}
+    >
+      <span className="text-xs uppercase tracking-wide text-muted-foreground font-medium">L</span>
       <div className="w-16 h-px bg-border relative">
         <div className="absolute left-1/2 -top-[2px] h-[5px] w-px bg-border" />
         <div
@@ -23,36 +29,39 @@ export function LeanMeter({
           style={{ left: `${left}%`, backgroundColor: color }}
         />
       </div>
-      <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-medium">R</span>
-      {showLabel && (
-        <span className="text-xs text-muted-foreground ml-1">{leanLabel(score)}</span>
-      )}
+      <span className="text-xs uppercase tracking-wide text-muted-foreground font-medium">R</span>
+      {showLabel && <span className="text-xs text-muted-foreground ml-1">{leanLabel(score)}</span>}
     </div>
   );
 }
 
 export function SentimentDot({ sentiment }: { sentiment?: string }) {
   const s = (sentiment || "").toLowerCase();
-  const color =
-    s.startsWith("pos")
-      ? "var(--sent-pos)"
-      : s.startsWith("neg") || s === "alarmist" || s === "critical"
-        ? "var(--sent-neg)"
-        : "var(--sent-neu)";
-  const label = sentiment
-    ? sentiment.charAt(0).toUpperCase() + sentiment.slice(1)
-    : "Neutral";
+  const color = s.startsWith("pos")
+    ? "var(--sent-pos)"
+    : s.startsWith("neg") || s === "alarmist" || s === "critical"
+      ? "var(--sent-neg)"
+      : "var(--sent-neu)";
+  const label = sentiment ? sentiment.charAt(0).toUpperCase() + sentiment.slice(1) : "Neutral";
+  const Icon = s.startsWith("pos")
+    ? TrendingUp
+    : s.startsWith("neg") || s === "alarmist" || s === "critical"
+      ? TrendingDown
+      : Minus;
   return (
-    <div className="flex items-center gap-2 text-xs font-medium" style={{ color }}>
-      <span className="size-1.5 rounded-full" style={{ backgroundColor: color }} />
-      {label}
+    <div
+      className="inline-flex items-center gap-1.5 text-xs font-medium text-foreground"
+      aria-label={`Sentiment: ${label}`}
+    >
+      <Icon className="size-3.5" style={{ color }} aria-hidden />
+      <span>{label}</span>
     </div>
   );
 }
 
-export function VerifiedBadge({ children = "Verified Statistics" }: { children?: React.ReactNode }) {
+export function VerifiedBadge({ children = "Verified" }: { children?: React.ReactNode }) {
   return (
-    <span className="inline-flex items-center gap-1.5 text-xs font-medium px-2 py-1 rounded text-verified bg-verified/5 border border-verified/15">
+    <span className="inline-flex items-center gap-1.5 text-xs font-medium px-2 py-1 rounded-md text-verified bg-verified/10 border border-verified/30">
       <span className="text-[10px]">✓</span>
       {children}
     </span>
@@ -61,8 +70,60 @@ export function VerifiedBadge({ children = "Verified Statistics" }: { children?:
 
 export function FrameworkChip({ children }: { children: React.ReactNode }) {
   return (
-    <span className="text-xs font-medium text-muted-foreground border border-border px-2 py-1 rounded">
+    <span className="text-xs font-medium text-muted-foreground border border-border px-2 py-1 rounded-md">
       {children}
     </span>
+  );
+}
+
+export function LeanPill({ score }: { score?: number }) {
+  const color = leanColorVar(score);
+  const label = leanLabel(score);
+  return (
+    <Badge
+      variant="outline"
+      className="h-7 rounded-full border-border/80 bg-background px-2.5 text-xs font-medium text-foreground"
+      aria-label={`Political lean: ${label}`}
+    >
+      <span
+        className="size-1.5 rounded-full mr-1.5"
+        style={{ backgroundColor: color }}
+        aria-hidden
+      />
+      {label}
+    </Badge>
+  );
+}
+
+export function FrameworkCue({
+  placement,
+  className,
+}: {
+  placement?: FrameworkPlacement;
+  className?: string;
+}) {
+  if (!placement?.framework?.name) return null;
+  const position = Math.max(-1, Math.min(1, placement.position ?? 0));
+  const left = ((position + 1) / 2) * 100;
+  const frameworkName = placement.framework.name;
+  return (
+    <div
+      className={cn(
+        "inline-flex max-w-full items-center gap-2 text-xs text-muted-foreground",
+        className,
+      )}
+      aria-label={`Framework cue: ${frameworkName}`}
+      title={placement.explanation || frameworkName}
+    >
+      <span className="max-w-[8.5rem] truncate sm:max-w-[11rem]">{frameworkName}</span>
+      <span className="relative h-px w-12 shrink-0 bg-border" aria-hidden>
+        <span className="absolute left-1/2 -top-[2px] h-[5px] w-px bg-border" />
+        <span
+          className="absolute top-1/2 size-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-foreground"
+          style={{ left: `${left}%` }}
+        />
+      </span>
+      <span className="sr-only">{placement.explanation || frameworkName}</span>
+    </div>
   );
 }

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -23,10 +23,10 @@ const badgeVariants = cva(
 );
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
+  extends React.HTMLAttributes<HTMLSpanElement>, VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
-  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+  return <span className={cn(badgeVariants({ variant }), className)} {...props} />;
 }
 
 export { Badge, badgeVariants };

--- a/frontend/src/components/ui/filter-chip.tsx
+++ b/frontend/src/components/ui/filter-chip.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const filterChipVariants = cva(
+  "inline-flex items-center justify-center rounded-full border font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      selected: {
+        true: "border-primary bg-primary text-primary-foreground",
+        false:
+          "border-border text-muted-foreground hover:border-foreground hover:bg-accent hover:text-foreground",
+      },
+      size: {
+        sm: "h-8 px-3 text-xs",
+        md: "h-9 px-3.5 text-sm",
+      },
+    },
+    defaultVariants: {
+      selected: false,
+      size: "sm",
+    },
+  },
+);
+
+type FilterChipProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  Omit<VariantProps<typeof filterChipVariants>, "selected"> & {
+    selected?: boolean;
+  };
+
+export function FilterChip({ className, selected = false, size, ...props }: FilterChipProps) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      className={cn(filterChipVariants({ selected, size }), className)}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/components/ui/filter-select.tsx
+++ b/frontend/src/components/ui/filter-select.tsx
@@ -1,0 +1,46 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type FilterSelectOption = {
+  value: string;
+  label: string;
+};
+
+export function FilterSelect({
+  id,
+  label,
+  value,
+  onValueChange,
+  options,
+  triggerClassName,
+}: {
+  id?: string;
+  label: string;
+  value: string;
+  onValueChange: (value: string) => void;
+  options: FilterSelectOption[];
+  triggerClassName?: string;
+}) {
+  return (
+    <label className="flex items-center gap-2 text-muted-foreground">
+      <span className="uppercase tracking-wide text-xs">{label}</span>
+      <Select value={value} onValueChange={onValueChange}>
+        <SelectTrigger id={id} className={triggerClassName}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </label>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,8 +4,7 @@
 const configuredApiUrl = (import.meta.env.VITE_API_URL as string | undefined)?.replace(/\/$/, "");
 
 export const API_BASE =
-  configuredApiUrl ||
-  (import.meta.env.DEV ? "http://localhost:8000" : "https://api.pulsenews.app");
+  configuredApiUrl || (import.meta.env.DEV ? "http://localhost:8000" : "https://api.pulsenews.app");
 
 const TOKEN_KEY = "token";
 
@@ -71,12 +70,7 @@ export async function api<T = unknown>(path: string, opts: FetchOpts = {}): Prom
     res = await fetch(url, {
       ...rest,
       headers: finalHeaders,
-      body:
-        body === undefined
-          ? undefined
-          : body instanceof FormData
-            ? body
-            : JSON.stringify(body),
+      body: body === undefined ? undefined : body instanceof FormData ? body : JSON.stringify(body),
     });
   } catch (e) {
     throw new ApiError(0, "Network error — could not reach Pulse API");

--- a/frontend/src/lib/theme.tsx
+++ b/frontend/src/lib/theme.tsx
@@ -8,10 +8,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setTheme] = useState<Theme>("light");
 
   useEffect(() => {
-    const stored = (typeof window !== "undefined" && window.localStorage.getItem(KEY)) as Theme | null;
+    const stored = (typeof window !== "undefined" &&
+      window.localStorage.getItem(KEY)) as Theme | null;
     const prefersDark =
-      typeof window !== "undefined" &&
-      window.matchMedia?.("(prefers-color-scheme: dark)").matches;
+      typeof window !== "undefined" && window.matchMedia?.("(prefers-color-scheme: dark)").matches;
     const initial: Theme = stored || (prefersDark ? "dark" : "light");
     setTheme(initial);
     document.documentElement.classList.toggle("dark", initial === "dark");

--- a/frontend/src/routes/_app.admin.tsx
+++ b/frontend/src/routes/_app.admin.tsx
@@ -122,10 +122,8 @@ const JOB_TRIGGER_IDS = [
   "reanalyze_unanalyzed_failed",
 ] as const;
 
-export const Route = createFileRoute("/_app/admin")<{
-  tab?: AdminTab;
-}>({
-  validateSearch: (search) => {
+export const Route = createFileRoute("/_app/admin")({
+  validateSearch: (search: Record<string, unknown>) => {
     const tab = search.tab;
     if (
       tab === "dashboard" ||

--- a/frontend/src/routes/_app.analytics.tsx
+++ b/frontend/src/routes/_app.analytics.tsx
@@ -15,6 +15,7 @@ import {
   Scatter,
   ZAxis,
 } from "recharts";
+import { ChevronDown } from "lucide-react";
 import { ApiError, api } from "@/lib/api";
 import { toast } from "sonner";
 
@@ -170,13 +171,17 @@ function AnalyticsPage() {
       <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
         <Stat label="Last 7 days" value={insights?.momentum.last_7_days ?? 0} />
         <Stat label="Previous 7 days" value={insights?.momentum.previous_7_days ?? 0} />
-        <Stat
-          label="Momentum"
-          value={momentumDelta > 0 ? `+${momentumDelta}` : momentumDelta}
-        />
+        <Stat label="Momentum" value={momentumDelta > 0 ? `+${momentumDelta}` : momentumDelta} />
       </div>
 
       <Section title="Sentiment over time" subtitle="Average sentiment grouped by political lean">
+        <Legend
+          items={[
+            { label: "Left-leaning coverage", color: "var(--sent-pos)" },
+            { label: "Center coverage", color: "var(--sent-neu)" },
+            { label: "Right-leaning coverage", color: "var(--sent-neg)" },
+          ]}
+        />
         <div className="h-72">
           <ResponsiveContainer>
             <LineChart data={sentiment}>
@@ -221,6 +226,13 @@ function AnalyticsPage() {
         title="Political lean distribution"
         subtitle="Where the stories you read sit on the spectrum"
       >
+        <Legend
+          items={[
+            { label: "Left", color: "var(--lean-l)" },
+            { label: "Center", color: "var(--lean-c)" },
+            { label: "Right", color: "var(--lean-r)" },
+          ]}
+        />
         <div className="h-72">
           <ResponsiveContainer>
             <BarChart data={bias}>
@@ -298,18 +310,33 @@ function AnalyticsPage() {
         }
       >
         {frameworkAxes.length < 2 || heatmap.length === 0 ? (
-          <p className="text-sm text-muted-foreground">Heatmap is unavailable until enough framework mappings exist.</p>
+          <p className="text-sm text-muted-foreground">
+            Heatmap is unavailable until enough framework mappings exist.
+          </p>
         ) : (
           <div className="h-80">
             <ResponsiveContainer>
               <ScatterChart margin={{ top: 20, right: 20, left: 10, bottom: 20 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
-                <XAxis type="number" dataKey="x" domain={[-10, 10]} stroke="var(--muted-foreground)" />
-                <YAxis type="number" dataKey="y" domain={[-10, 10]} stroke="var(--muted-foreground)" />
+                <XAxis
+                  type="number"
+                  dataKey="x"
+                  domain={[-10, 10]}
+                  stroke="var(--muted-foreground)"
+                />
+                <YAxis
+                  type="number"
+                  dataKey="y"
+                  domain={[-10, 10]}
+                  stroke="var(--muted-foreground)"
+                />
                 <ZAxis type="number" dataKey="article_count" range={[80, 400]} />
                 <Tooltip
                   cursor={{ strokeDasharray: "3 3" }}
-                  formatter={(value: number, name: string) => [value, name === "article_count" ? "Articles" : name]}
+                  formatter={(value: number, name: string) => [
+                    value,
+                    name === "article_count" ? "Articles" : name,
+                  ]}
                 />
                 <Scatter data={heatmap} fill="var(--primary)" />
               </ScatterChart>
@@ -333,11 +360,17 @@ function AnalyticsPage() {
                 key={framework.id}
                 className="rounded-md border border-border bg-background px-4 py-3"
               >
-                <summary className="cursor-pointer list-none font-medium">
-                  {framework.name}
-                  <span className="ml-2 text-xs text-muted-foreground">
-                    ({framework.article_count} mapped articles)
+                <summary className="cursor-pointer list-none font-medium inline-flex w-full items-center justify-between gap-3 rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+                  <span>
+                    {framework.name}
+                    <span className="ml-2 text-xs text-muted-foreground">
+                      ({framework.article_count} mapped articles)
+                    </span>
                   </span>
+                  <ChevronDown
+                    className="size-4 text-muted-foreground transition-transform details-chevron"
+                    aria-hidden
+                  />
                 </summary>
                 <div className="mt-3 space-y-2 text-sm text-muted-foreground">
                   <p>{framework.description}</p>
@@ -389,5 +422,22 @@ function Section({
       </div>
       <div className="border border-border rounded-lg p-5 bg-card">{children}</div>
     </section>
+  );
+}
+
+function Legend({ items }: { items: { label: string; color: string }[] }) {
+  return (
+    <div className="mb-4 flex flex-wrap gap-x-4 gap-y-2 text-xs text-muted-foreground">
+      {items.map((item) => (
+        <div key={item.label} className="inline-flex items-center gap-2">
+          <span
+            className="size-2 rounded-full"
+            style={{ backgroundColor: item.color }}
+            aria-hidden
+          />
+          <span>{item.label}</span>
+        </div>
+      ))}
+    </div>
   );
 }

--- a/frontend/src/routes/_app.analyze.tsx
+++ b/frontend/src/routes/_app.analyze.tsx
@@ -31,6 +31,14 @@ function AnalyzePage() {
     const frameworks = Array.isArray(raw.frameworks) ? raw.frameworks : [];
     const stats = Array.isArray(raw.statistics) ? raw.statistics : [];
 
+    const rawPoliticalLean = analysis.political_lean;
+    const politicalLean =
+      typeof rawPoliticalLean === "number"
+        ? rawPoliticalLean
+        : typeof rawPoliticalLean === "string"
+          ? Number(rawPoliticalLean)
+          : undefined;
+
     return {
       id: (raw.id as string | number | undefined) ?? "temp",
       title: String(raw.title ?? "Untitled"),
@@ -43,8 +51,8 @@ function AnalyzePage() {
           : undefined,
       sentiment_score:
         typeof analysis.sentiment_score === "number" ? analysis.sentiment_score : undefined,
-      political_lean:
-        typeof analysis.political_lean === "string" ? analysis.political_lean : undefined,
+      sentiment: typeof analysis.sentiment === "string" ? analysis.sentiment : undefined,
+      political_lean: Number.isFinite(politicalLean) ? politicalLean : undefined,
       has_verified_stats: stats.length > 0,
       frameworks: frameworks.map((f) => {
         const row = (f as Record<string, unknown>) ?? {};

--- a/frontend/src/routes/_app.article.$id.tsx
+++ b/frontend/src/routes/_app.article.$id.tsx
@@ -8,6 +8,7 @@ import { LeanMeter, SentimentDot, VerifiedBadge } from "@/components/Signals";
 import { ArticleCard } from "@/components/ArticleCard";
 import { useAuth } from "@/lib/auth";
 import { timeAgo } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
 export const Route = createFileRoute("/_app/article/$id")({
   head: () => ({ meta: [{ title: "Article — Pulse" }] }),
@@ -35,7 +36,10 @@ function ArticlePage() {
     setLoading(true);
     api<Article>(`/articles/${id}`)
       .then((a) => !cancelled && setArticle(a))
-      .catch((err) => !cancelled && setError(err instanceof ApiError ? err.message : "Could not load article"))
+      .catch(
+        (err) =>
+          !cancelled && setError(err instanceof ApiError ? err.message : "Could not load article"),
+      )
       .finally(() => !cancelled && setLoading(false));
     return () => {
       cancelled = true;
@@ -57,17 +61,26 @@ function ArticlePage() {
   }
 
   if (loading) {
-    return <div className="max-w-[760px] mx-auto px-6 py-20 text-muted-foreground">Loading article…</div>;
+    return (
+      <div className="max-w-[760px] mx-auto px-6 py-20 text-muted-foreground">Loading article…</div>
+    );
   }
   if (error || !article) {
     return (
       <div className="max-w-[760px] mx-auto px-6 py-20 text-center">
         <p className="text-destructive mb-4">{error || "Article not found"}</p>
         <div className="flex items-center justify-center gap-4">
-          <button onClick={refetch} className="px-4 py-2 rounded-md border border-border hover:bg-accent text-sm">
+          <button
+            onClick={refetch}
+            className="px-4 py-2 rounded-md border border-border hover:bg-accent text-sm"
+          >
             Retry
           </button>
-          <Link to="/feed" className="underline underline-offset-4">
+          <Link
+            to="/feed"
+            search={{ page: 1, q: "", topic: "", lean: "", sort: "newest", fav: false }}
+            className="underline underline-offset-4"
+          >
             Back to feed
           </Link>
         </div>
@@ -85,7 +98,8 @@ function ArticlePage() {
     <article className="max-w-[760px] mx-auto px-6 py-12">
       <Link
         to="/feed"
-        className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-10"
+        search={{ page: 1, q: "", topic: "", lean: "", sort: "newest", fav: false }}
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
       >
         <ArrowLeft className="size-4" /> Back to feed
       </Link>
@@ -117,32 +131,29 @@ function ArticlePage() {
         )}
 
         <div className="mt-8 flex flex-wrap items-center gap-4">
-          <button
+          <Button
             onClick={toggleFav}
-            className={`inline-flex items-center gap-2 px-3 py-2 rounded-md border text-sm transition-colors ${
-              article.is_favorited
-                ? "bg-primary text-primary-foreground border-primary"
-                : "border-border hover:bg-accent"
+            aria-pressed={!!article.is_favorited}
+            variant="outline"
+            className={`${
+              article.is_favorited ? "border-border bg-accent text-foreground hover:bg-accent" : ""
             }`}
           >
             <Star className="size-4" fill={article.is_favorited ? "currentColor" : "none"} />
             {article.is_favorited ? "Saved" : "Save"}
-          </button>
+          </Button>
           {article.url && (
-            <a
-              href={article.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-3 py-2 rounded-md border border-border hover:bg-accent text-sm transition-colors"
-            >
-              Read original <ExternalLink className="size-3.5" />
-            </a>
+            <Button asChild>
+              <a href={article.url} target="_blank" rel="noopener noreferrer">
+                Read original <ExternalLink className="size-3.5" />
+              </a>
+            </Button>
           )}
         </div>
       </header>
 
       {/* Analysis bar */}
-      <section className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12 p-6 border border-border rounded-lg bg-card">
+      <section className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-12 p-5 border border-border rounded-lg bg-card">
         <Stat label="Sentiment">
           <SentimentDot sentiment={article.sentiment} />
         </Stat>
@@ -196,7 +207,9 @@ function ArticlePage() {
       {(!article.statistics || article.statistics.length === 0) && (
         <section className="mb-12">
           <SectionTitle>Statistic verification</SectionTitle>
-          <p className="text-sm text-muted-foreground">No verified statistics are available for this article yet.</p>
+          <p className="text-sm text-muted-foreground">
+            No verified statistics are available for this article yet.
+          </p>
         </section>
       )}
 
@@ -216,7 +229,7 @@ function ArticlePage() {
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
   return (
-    <h2 className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-6 pb-3 border-b border-border">
+    <h2 className="text-xs uppercase tracking-[0.16em] text-muted-foreground mb-6 pb-3 border-b border-border">
       {children}
     </h2>
   );
@@ -225,7 +238,7 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
 function Stat({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div>
-      <p className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground mb-2">{label}</p>
+      <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground mb-2">{label}</p>
       {children}
     </div>
   );
@@ -251,7 +264,9 @@ function FrameworkAxis({ placement }: { placement: FrameworkPlacement }) {
         </div>
         <span className="font-medium">{framework?.axis_right || "Right"}</span>
       </div>
-      {explanation && <p className="text-sm text-muted-foreground leading-relaxed">{explanation}</p>}
+      {explanation && (
+        <p className="text-sm text-muted-foreground leading-relaxed">{explanation}</p>
+      )}
     </div>
   );
 }
@@ -268,7 +283,9 @@ function StatRow({ stat }: { stat: StatVerification }) {
     <div className="border border-border rounded-md p-4">
       <div className="flex items-start justify-between gap-4">
         <p className="text-sm leading-relaxed">{stat.claim}</p>
-        <span className={`shrink-0 text-[10px] uppercase tracking-wider px-2 py-1 rounded border ${color}`}>
+        <span
+          className={`shrink-0 text-xs uppercase tracking-wide px-2 py-1 rounded border ${color}`}
+        >
           {stat.verdict || "Unverified"}
         </span>
       </div>

--- a/frontend/src/routes/_app.challenge.$date.tsx
+++ b/frontend/src/routes/_app.challenge.$date.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, type FormEvent } from "react";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { Calendar, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 type Claim = {
   id: string | number;
@@ -79,7 +80,11 @@ function ChallengePage() {
   }
 
   if (loading) {
-    return <div className="max-w-[760px] mx-auto px-6 py-16 text-muted-foreground">Loading challenge…</div>;
+    return (
+      <div className="max-w-[760px] mx-auto px-6 py-16 text-muted-foreground">
+        Loading challenge…
+      </div>
+    );
   }
   if (!challenge) {
     return (
@@ -99,7 +104,9 @@ function ChallengePage() {
         {challenge.title || "Weekly news challenge"}
       </h1>
       {challenge.description && (
-        <p className="mt-4 text-lg text-muted-foreground leading-relaxed">{challenge.description}</p>
+        <p className="mt-4 text-lg text-muted-foreground leading-relaxed">
+          {challenge.description}
+        </p>
       )}
 
       <form onSubmit={onSubmit} className="mt-12 space-y-6">
@@ -110,34 +117,38 @@ function ChallengePage() {
             </legend>
             <p className="font-serif text-xl font-medium mb-4">{c.claim_text}</p>
             <div className="flex gap-3">
-              <button
+              <Button
                 type="button"
                 onClick={() => {
                   setSelectedClaimId(String(c.id));
                   setAgreementLevel("agree");
                 }}
+                variant="outline"
                 className={`flex-1 py-2.5 rounded-md border transition-colors ${
                   selectedClaimId === String(c.id) && agreementLevel === "agree"
-                    ? "bg-primary text-primary-foreground border-primary"
-                    : "border-border hover:bg-accent"
+                    ? "bg-accent border-foreground text-foreground"
+                    : ""
                 }`}
+                aria-pressed={selectedClaimId === String(c.id) && agreementLevel === "agree"}
               >
                 I agree
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
                 onClick={() => {
                   setSelectedClaimId(String(c.id));
                   setAgreementLevel("disagree");
                 }}
+                variant="outline"
                 className={`flex-1 py-2.5 rounded-md border transition-colors ${
                   selectedClaimId === String(c.id) && agreementLevel === "disagree"
-                    ? "bg-primary text-primary-foreground border-primary"
-                    : "border-border hover:bg-accent"
+                    ? "bg-accent border-foreground text-foreground"
+                    : ""
                 }`}
+                aria-pressed={selectedClaimId === String(c.id) && agreementLevel === "disagree"}
               >
                 I disagree
-              </button>
+              </Button>
             </div>
             {submitted && selectedClaimId === String(c.id) && (
               <p className="mt-3 text-sm text-sent-pos">
@@ -148,9 +159,7 @@ function ChallengePage() {
           </fieldset>
         ))}
         {!submitted && canRespond && (challenge.claims?.length ?? 0) > 0 && (
-          <button className="px-5 py-3 rounded-md bg-primary text-primary-foreground font-medium">
-            Submit answers
-          </button>
+          <Button className="h-11 px-5">Submit answers</Button>
         )}
         {!canRespond && (
           <p className="text-sm text-muted-foreground">

--- a/frontend/src/routes/_app.feed.tsx
+++ b/frontend/src/routes/_app.feed.tsx
@@ -6,6 +6,9 @@ import { useAuth } from "@/lib/auth";
 import type { Article, Source, Topic, Paginated } from "@/lib/types";
 import { ArticleCard } from "@/components/ArticleCard";
 import { Search, ChevronLeft, ChevronRight } from "lucide-react";
+import { FilterChip } from "@/components/ui/filter-chip";
+import { FilterSelect } from "@/components/ui/filter-select";
+import { Button } from "@/components/ui/button";
 
 type FeedSearch = {
   page: number;
@@ -28,7 +31,10 @@ export const Route = createFileRoute("/_app/feed")({
   head: () => ({
     meta: [
       { title: "Your feed — Pulse" },
-      { name: "description", content: "Personalized news with summaries, sentiment, and ethical lens analysis." },
+      {
+        name: "description",
+        content: "Personalized news with summaries, sentiment, and ethical lens analysis.",
+      },
     ],
   }),
   component: FeedPage,
@@ -82,7 +88,10 @@ function FeedPage() {
     if (search.topic) params.topics = [search.topic];
     if (search.lean) params.political_leans = [search.lean];
 
-    api<Paginated<Article> | { articles: Article[]; total_count: number } | Article[]>("/feed/articles", { query: params })
+    api<Paginated<Article> | { articles: Article[]; total_count: number } | Article[]>(
+      "/feed/articles",
+      { query: params },
+    )
       .then((res) => {
         if (cancelled) return;
         const items = Array.isArray(res) ? res : "articles" in res ? res.articles : res.items || [];
@@ -113,7 +122,14 @@ function FeedPage() {
   function update(patch: Partial<FeedSearch>) {
     navigate({
       to: "/feed",
-      search: (prev: FeedSearch) => ({ ...prev, ...patch, page: patch.page ?? 1 }),
+      search: (prev) => ({
+        page: patch.page ?? 1,
+        q: patch.q ?? prev.q ?? "",
+        topic: patch.topic ?? prev.topic ?? "",
+        lean: patch.lean ?? prev.lean ?? "",
+        sort: patch.sort ?? prev.sort ?? "newest",
+        fav: patch.fav ?? prev.fav ?? false,
+      }),
     });
   }
 
@@ -153,8 +169,8 @@ function FeedPage() {
   );
 
   return (
-    <div className="max-w-[1024px] mx-auto px-6 py-12">
-      <header className="flex flex-col gap-6 mb-12">
+    <div className="max-w-[1024px] mx-auto px-6 py-8 md:py-10">
+      <header className="flex flex-col gap-5 mb-8 md:mb-10">
         <div>
           <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-3">
             {search.fav ? "Saved articles" : "Today's coverage"}
@@ -171,8 +187,12 @@ function FeedPage() {
           }}
           className="relative max-w-md"
         >
+          <label htmlFor="feed-search" className="sr-only">
+            Search stories
+          </label>
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
           <input
+            id="feed-search"
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
             placeholder="Search stories…"
@@ -180,67 +200,53 @@ function FeedPage() {
           />
         </form>
 
-        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div className="flex flex-col gap-4">
           <div className="flex flex-wrap items-center gap-2 text-sm">
-            <span className="text-muted-foreground mr-2 uppercase tracking-wider text-xs">
+            <span className="text-muted-foreground mr-2 uppercase tracking-wide text-xs">
               Topic
             </span>
-            <button
-              onClick={() => update({ topic: "" })}
-              className={chip(!search.topic)}
-            >
+            <FilterChip selected={!search.topic} onClick={() => update({ topic: "" })}>
               All
-            </button>
+            </FilterChip>
             {topics.slice(0, 8).map((t) => (
-              <button
+              <FilterChip
                 key={t.id}
+                selected={search.topic === t.name}
                 onClick={() => update({ topic: t.name })}
-                className={chip(search.topic === t.name)}
               >
                 {t.name}
-              </button>
+              </FilterChip>
             ))}
           </div>
 
-          <div className="flex items-center gap-4 text-sm">
-            <label className="flex items-center gap-2 text-muted-foreground">
-              <span className="uppercase tracking-wider text-xs">Lean</span>
-              <select
-                value={search.lean}
-                onChange={(e) => update({ lean: e.target.value })}
-                className="bg-transparent border-b border-border pb-0.5 focus:outline-none text-foreground"
-              >
-                {leanOptions.map((o) => (
-                  <option key={o.v} value={o.v}>
-                    {o.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="flex items-center gap-2 text-muted-foreground">
-              <span className="uppercase tracking-wider text-xs">Sort</span>
-              <select
-                value={search.sort}
-                onChange={(e) => update({ sort: e.target.value })}
-                className="bg-transparent border-b border-border pb-0.5 focus:outline-none text-foreground"
-              >
-                <option value="newest">Most recent</option>
-                <option value="oldest">Oldest first</option>
-                <option value="sentiment_high">Most positive</option>
-                <option value="sentiment_low">Most negative</option>
-              </select>
-            </label>
+          <div className="flex flex-wrap items-center gap-3 text-sm">
+            <FilterSelect
+              label="Lean"
+              value={search.lean}
+              onValueChange={(value) => update({ lean: value })}
+              options={leanOptions.map((option) => ({ value: option.v, label: option.label }))}
+              triggerClassName="h-9 w-[10.5rem] bg-background"
+            />
+            <FilterSelect
+              label="Sort"
+              value={search.sort}
+              onValueChange={(value) => update({ sort: value })}
+              options={[
+                { value: "newest", label: "Most recent" },
+                { value: "oldest", label: "Oldest first" },
+                { value: "sentiment_high", label: "Most positive" },
+                { value: "sentiment_low", label: "Most negative" },
+              ]}
+              triggerClassName="h-9 w-[10.5rem] bg-background"
+            />
             {user && (
-              <button
+              <FilterChip
+                size="md"
+                selected={search.fav}
                 onClick={() => update({ fav: !search.fav })}
-                className={`text-xs uppercase tracking-wider px-2 py-1 rounded border ${
-                  search.fav
-                    ? "border-foreground text-foreground"
-                    : "border-border text-muted-foreground hover:text-foreground"
-                }`}
               >
                 {search.fav ? "Saved" : "Show saved"}
-              </button>
+              </FilterChip>
             )}
           </div>
         </div>
@@ -254,22 +260,25 @@ function FeedPage() {
         <div className="py-20 text-center">
           <p className="text-destructive mb-3">We couldn't load your feed right now.</p>
           <p className="text-sm text-muted-foreground mb-6">{loadError}</p>
-          <button
-            onClick={() => update({ page: search.page })}
-            className="px-4 py-2 rounded-md border border-border hover:bg-accent text-sm"
-          >
+          <Button onClick={() => update({ page: search.page })} variant="outline" size="default">
             Try again
-          </button>
+          </Button>
         </div>
       ) : articles.length === 0 ? (
         <div className="py-20 text-center text-muted-foreground">
           <p className="mb-4">No articles match these filters.</p>
-          <button
-            onClick={() => navigate({ to: "/feed", search: { page: 1, q: "", topic: "", lean: "", sort: "newest", fav: false } })}
-            className="px-4 py-2 rounded-md border border-border hover:bg-accent text-sm text-foreground"
+          <Button
+            onClick={() =>
+              navigate({
+                to: "/feed",
+                search: { page: 1, q: "", topic: "", lean: "", sort: "newest", fav: false },
+              })
+            }
+            variant="outline"
+            size="default"
           >
             Clear filters
-          </button>
+          </Button>
         </div>
       ) : (
         <div className="flex flex-col">
@@ -281,33 +290,29 @@ function FeedPage() {
 
       {sources.length > 0 && articles.length > 0 && (
         <div className="mt-16 pt-6 border-t-[3px] border-border flex items-center justify-between text-sm font-medium">
-          <button
+          <Button
             disabled={search.page <= 1}
             onClick={() => update({ page: search.page - 1 })}
-            className="text-muted-foreground hover:text-foreground transition-colors flex items-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed"
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground"
           >
             <ChevronLeft className="size-4" /> Newer
-          </button>
+          </Button>
           <span className="text-muted-foreground tabular-nums text-xs uppercase tracking-wider">
             Page {search.page} of {totalPages}
           </span>
-          <button
+          <Button
             disabled={search.page >= totalPages}
             onClick={() => update({ page: search.page + 1 })}
-            className="text-foreground hover:text-muted-foreground transition-colors flex items-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed"
+            variant="ghost"
+            size="sm"
+            className="text-foreground"
           >
             Older <ChevronRight className="size-4" />
-          </button>
+          </Button>
         </div>
       )}
     </div>
   );
-}
-
-function chip(active: boolean) {
-  return `px-3 py-1 rounded-full transition-colors ${
-    active
-      ? "bg-primary text-primary-foreground"
-      : "border border-border text-muted-foreground hover:border-foreground hover:text-foreground"
-  }`;
 }

--- a/frontend/src/routes/_app.how-it-works.tsx
+++ b/frontend/src/routes/_app.how-it-works.tsx
@@ -7,7 +7,8 @@ export const Route = createFileRoute("/_app/how-it-works")({
       { title: "How Pulse works" },
       {
         name: "description",
-        content: "From RSS aggregation to AI analysis, framework mapping, statistic verification, and the morning newsletter.",
+        content:
+          "From RSS aggregation to AI analysis, framework mapping, statistic verification, and the morning newsletter.",
       },
     ],
   }),
@@ -15,12 +16,36 @@ export const Route = createFileRoute("/_app/how-it-works")({
 });
 
 const steps = [
-  { Icon: Rss, title: "Aggregate", body: "We pull continuously from a roster of trusted RSS sources, each rated on bias and credibility." },
-  { Icon: Brain, title: "Analyze", body: "An LLM generates a summary, sentiment reading, and political lean — surfaced never sensationalized." },
-  { Icon: Filter, title: "Frame", body: "Each story is mapped onto ethical frameworks like liberty vs. welfare or sovereignty vs. cooperation." },
-  { Icon: ShieldCheck, title: "Verify", body: "Statistical claims are traced through a multi-stage pipeline, scored for confidence and credibility." },
-  { Icon: Sparkles, title: "Personalize", body: "Your topics, sources, and reading shape what surfaces in your feed." },
-  { Icon: Mail, title: "Deliver", body: "Optional daily newsletter brings the day's signal — not noise — to your inbox." },
+  {
+    Icon: Rss,
+    title: "Aggregate",
+    body: "We pull continuously from a roster of trusted RSS sources, each rated on bias and credibility.",
+  },
+  {
+    Icon: Brain,
+    title: "Analyze",
+    body: "An LLM generates a summary, sentiment reading, and political lean — surfaced never sensationalized.",
+  },
+  {
+    Icon: Filter,
+    title: "Frame",
+    body: "Each story is mapped onto ethical frameworks like liberty vs. welfare or sovereignty vs. cooperation.",
+  },
+  {
+    Icon: ShieldCheck,
+    title: "Verify",
+    body: "Statistical claims are traced through a multi-stage pipeline, scored for confidence and credibility.",
+  },
+  {
+    Icon: Sparkles,
+    title: "Personalize",
+    body: "Your topics, sources, and reading shape what surfaces in your feed.",
+  },
+  {
+    Icon: Mail,
+    title: "Deliver",
+    body: "Optional daily newsletter brings the day's signal — not noise — to your inbox.",
+  },
 ];
 
 function HowItWorks() {

--- a/frontend/src/routes/_app.index.tsx
+++ b/frontend/src/routes/_app.index.tsx
@@ -5,7 +5,10 @@ import { ArrowRight, Sparkles, ShieldCheck, Compass } from "lucide-react";
 export const Route = createFileRoute("/_app/")({
   beforeLoad: () => {
     if (typeof window !== "undefined" && getToken()) {
-      throw redirect({ to: "/feed" });
+      throw redirect({
+        to: "/feed",
+        search: { page: 1, q: "", topic: "", lean: "", sort: "newest", fav: false },
+      });
     }
   },
   head: () => ({

--- a/frontend/src/routes/_app.insights.tsx
+++ b/frontend/src/routes/_app.insights.tsx
@@ -13,7 +13,9 @@ export const Route = createFileRoute("/_app/insights")({
 function InsightsPage() {
   return (
     <div className="max-w-[760px] mx-auto px-6 py-16">
-      <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-3">Lens on discourse</p>
+      <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-3">
+        Lens on discourse
+      </p>
       <h1 className="font-serif text-5xl font-medium tracking-tight leading-tight">
         Patterns from the week.
       </h1>

--- a/frontend/src/routes/_app.preferences.tsx
+++ b/frontend/src/routes/_app.preferences.tsx
@@ -5,10 +5,15 @@ import { api, ApiError } from "@/lib/api";
 import type { Source, Topic } from "@/lib/types";
 import { useAuth } from "@/lib/auth";
 import { useTheme } from "@/lib/theme";
+import { FilterChip } from "@/components/ui/filter-chip";
 
 type PrefSearch = { tab: "topics" | "sources" | "settings" };
 type PreferenceSummary = { topics?: Array<{ id: number; is_active: boolean }> };
-type SourcePreference = Source & { source_id?: number; subscribed?: boolean; organizational_bias?: string };
+type SourcePreference = Source & {
+  source_id?: number;
+  subscribed?: boolean;
+  organizational_bias?: string;
+};
 type UserSettings = {
   source_discovery_mode?: "none" | "some" | "open";
   article_order_preference?: "good_first" | "good_last" | "mixed";
@@ -59,7 +64,9 @@ function PreferencesPage() {
         setActiveSources(new Set(list.filter((s) => s.active !== false).map((s) => s.id)));
       })
       .catch(() => {});
-    api<typeof settings>("/preferences/settings").then(setSettings).catch(() => {});
+    api<typeof settings>("/preferences/settings")
+      .then(setSettings)
+      .catch(() => {});
   }, []);
 
   async function toggleTopic(t: Topic) {
@@ -141,17 +148,9 @@ function PreferencesPage() {
               {topics.map((t) => {
                 const on = subscribed.has(t.id);
                 return (
-                  <button
-                    key={t.id}
-                    onClick={() => toggleTopic(t)}
-                    className={`px-3 py-1.5 rounded-full text-sm border transition-colors ${
-                      on
-                        ? "bg-primary text-primary-foreground border-primary"
-                        : "border-border text-muted-foreground hover:text-foreground"
-                    }`}
-                  >
+                  <FilterChip key={t.id} selected={on} size="md" onClick={() => toggleTopic(t)}>
                     {t.name}
-                  </button>
+                  </FilterChip>
                 );
               })}
               {topics.length === 0 && (
@@ -163,9 +162,7 @@ function PreferencesPage() {
 
         {tab === "sources" && (
           <div>
-            <p className="text-muted-foreground mb-6">
-              Choose which outlets feed into your Pulse.
-            </p>
+            <p className="text-muted-foreground mb-6">Choose which outlets feed into your Pulse.</p>
             <div className="border border-border rounded-lg divide-y divide-border">
               {sources.map((s) => {
                 const on = activeSources.has(s.id);

--- a/frontend/src/routes/_app.privacy-policy.tsx
+++ b/frontend/src/routes/_app.privacy-policy.tsx
@@ -28,9 +28,13 @@ function PrivacyPage() {
       </p>
       <h2 className="font-serif text-2xl mt-10 mb-3">Your controls</h2>
       <p className="text-muted-foreground leading-relaxed">
-        Export or delete your account at any time from <strong className="text-foreground">Preferences → Settings</strong>.
-        For data requests, contact{" "}
-        <a href="mailto:privacy@pulsenews.app" className="underline underline-offset-4 text-foreground">
+        Export or delete your account at any time from{" "}
+        <strong className="text-foreground">Preferences → Settings</strong>. For data requests,
+        contact{" "}
+        <a
+          href="mailto:privacy@pulsenews.app"
+          className="underline underline-offset-4 text-foreground"
+        >
           privacy@pulsenews.app
         </a>
         .

--- a/frontend/src/routes/_app.sources.tsx
+++ b/frontend/src/routes/_app.sources.tsx
@@ -7,7 +7,10 @@ export const Route = createFileRoute("/_app/sources")({
   head: () => ({
     meta: [
       { title: "News sources — Pulse" },
-      { name: "description", content: "Browse the outlets behind Pulse: their bias, trust scores, and active status." },
+      {
+        name: "description",
+        content: "Browse the outlets behind Pulse: their bias, trust scores, and active status.",
+      },
     ],
   }),
   component: SourcesPage,
@@ -43,7 +46,10 @@ function SourcesPage() {
         ) : (
           <ul className="divide-y divide-border">
             {sources.map((s) => (
-              <li key={s.id} className="grid grid-cols-1 md:grid-cols-[1fr_auto_auto] gap-4 py-5 items-center">
+              <li
+                key={s.id}
+                className="grid grid-cols-1 md:grid-cols-[1fr_auto_auto] gap-4 py-5 items-center"
+              >
                 <div>
                   <h3 className="font-serif text-xl font-medium">{s.name}</h3>
                   {s.description && (
@@ -51,7 +57,7 @@ function SourcesPage() {
                   )}
                 </div>
                 <span className="text-xs uppercase tracking-wider text-muted-foreground">
-                  {(s.bias || s.organizational_bias) || "Unrated"}
+                  {s.bias || s.organizational_bias || "Unrated"}
                 </span>
                 {typeof s.trust_score === "number" && (
                   <span className="text-xs tabular-nums text-foreground border border-border px-2 py-1 rounded">

--- a/frontend/src/routes/login.callback.tsx
+++ b/frontend/src/routes/login.callback.tsx
@@ -22,7 +22,12 @@ function OAuthCallback() {
       hash.get("token");
     if (token) {
       setToken(token);
-      refresh().finally(() => navigate({ to: "/feed" }));
+      refresh().finally(() =>
+        navigate({
+          to: "/feed",
+          search: { page: 1, q: "", topic: "", lean: "", sort: "newest", fav: false },
+        }),
+      );
     } else {
       navigate({ to: "/login" });
     }

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -3,6 +3,7 @@ import { useState, type FormEvent } from "react";
 import { toast } from "sonner";
 import { useAuth } from "@/lib/auth";
 import { ApiError } from "@/lib/api";
+import { Button } from "@/components/ui/button";
 
 export const Route = createFileRoute("/login")({
   head: () => ({ meta: [{ title: "Sign in — Pulse" }] }),
@@ -22,7 +23,10 @@ function LoginPage() {
     try {
       await login(email, password);
       toast.success("Welcome back to Pulse");
-      navigate({ to: "/feed" });
+      navigate({
+        to: "/feed",
+        search: { page: 1, q: "", topic: "", lean: "", sort: "newest", fav: false },
+      });
     } catch (err) {
       toast.error(err instanceof ApiError ? err.message : "Sign in failed");
     } finally {
@@ -48,7 +52,10 @@ function LoginPage() {
           label="Password"
           id="password"
           right={
-            <Link to="/forgot-password" className="text-xs text-muted-foreground hover:text-foreground">
+            <Link
+              to="/forgot-password"
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
               Forgot?
             </Link>
           }
@@ -63,13 +70,9 @@ function LoginPage() {
             className="w-full px-3 py-2.5 bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring"
           />
         </Field>
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full py-2.5 rounded-md bg-primary text-primary-foreground font-medium hover:opacity-90 transition-opacity disabled:opacity-60"
-        >
+        <Button type="submit" disabled={loading} className="w-full h-10">
           {loading ? "Signing in..." : "Sign in"}
-        </button>
+        </Button>
       </form>
       <p className="mt-6 text-sm text-center text-muted-foreground">
         New to Pulse?{" "}

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -5,6 +5,8 @@ import { useAuth } from "@/lib/auth";
 import { api, ApiError } from "@/lib/api";
 import type { Topic } from "@/lib/types";
 import { AuthShell, Field } from "./login";
+import { FilterChip } from "@/components/ui/filter-chip";
+import { Button } from "@/components/ui/button";
 
 export const Route = createFileRoute("/signup")({
   head: () => ({ meta: [{ title: "Join Pulse" }] }),
@@ -94,36 +96,25 @@ function SignupPage() {
         {topics.length > 0 && (
           <div>
             <p className="text-sm font-medium mb-2">Topics you care about</p>
-            <p className="text-xs text-muted-foreground mb-3">Optional — you can change this later.</p>
+            <p className="text-xs text-muted-foreground mb-3">
+              Optional — you can change this later.
+            </p>
             <div className="flex flex-wrap gap-2">
               {topics.map((t) => {
                 const active = selected.has(t.id);
                 return (
-                  <button
-                    type="button"
-                    key={t.id}
-                    onClick={() => toggle(t.id)}
-                    className={`px-3 py-1.5 rounded-full text-sm border transition-colors ${
-                      active
-                        ? "bg-primary text-primary-foreground border-primary"
-                        : "border-border text-muted-foreground hover:text-foreground"
-                    }`}
-                  >
+                  <FilterChip key={t.id} selected={active} size="md" onClick={() => toggle(t.id)}>
                     {t.name}
-                  </button>
+                  </FilterChip>
                 );
               })}
             </div>
           </div>
         )}
 
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full py-2.5 rounded-md bg-primary text-primary-foreground font-medium hover:opacity-90 transition-opacity disabled:opacity-60"
-        >
+        <Button type="submit" disabled={loading} className="w-full h-10">
           {loading ? "Creating your account..." : "Create account"}
-        </button>
+        </Button>
       </form>
       <p className="mt-6 text-sm text-center text-muted-foreground">
         Already a member?{" "}

--- a/frontend/src/routes/welcome.tsx
+++ b/frontend/src/routes/welcome.tsx
@@ -11,23 +11,27 @@ function WelcomePage() {
   return (
     <div className="min-h-dvh bg-background text-foreground flex items-center justify-center px-6 py-16">
       <div className="max-w-xl text-center">
-        <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-6">Welcome aboard</p>
+        <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-6">
+          Welcome aboard
+        </p>
         <h1 className="font-serif text-5xl font-medium tracking-tight">
           Hello{user?.name ? `, ${user.name.split(" ")[0]}` : ""}.
         </h1>
         <p className="mt-6 text-lg text-muted-foreground leading-relaxed">
-          Your Pulse feed is ready. We've started tuning it to your topics — it gets sharper the more
-          you read.
+          Your Pulse feed is ready. We've started tuning it to your topics — it gets sharper the
+          more you read.
         </p>
         <div className="mt-10 flex flex-wrap gap-3 justify-center">
           <Link
             to="/feed"
+            search={{ page: 1, q: "", topic: "", lean: "", sort: "newest", fav: false }}
             className="px-5 py-3 rounded-md bg-primary text-primary-foreground font-medium hover:opacity-90 transition-opacity"
           >
             Open my feed
           </Link>
           <Link
             to="/preferences"
+            search={{ tab: "topics" }}
             className="px-5 py-3 rounded-md border border-border font-medium hover:bg-accent transition-colors"
           >
             Adjust preferences

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -197,13 +197,34 @@
     font-family: var(--font-sans);
   }
   /* Editorial headlines */
-  h1, h2, h3 {
+  h1,
+  h2,
+  h3 {
     font-family: var(--font-serif);
     letter-spacing: -0.015em;
   }
 }
 
 @layer utilities {
-  .text-balance { text-wrap: balance; }
-  .text-pretty { text-wrap: pretty; }
+  .text-balance {
+    text-wrap: balance;
+  }
+  .text-pretty {
+    text-wrap: pretty;
+  }
+
+  details[open] .details-chevron {
+    transform: rotate(180deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/llm_context.md
+++ b/llm_context.md
@@ -11,6 +11,26 @@
 - Statistic extraction and verification support
 - Source tracing multi-turn reasoning
 
+## Mobile usage notes
+- Expo mobile UI now consumes backend route outputs directly through generated TypeScript client functions in `mobile/app/lib/api-client-react/src/generated/api.ts`.
+- Advanced LLM-backed article endpoints consumed by mobile include:
+  - `GET /articles/{id}/opposing-viewpoints`
+  - `POST /articles/{id}/analyze-viewpoints`
+  - `GET /articles/{id}/coverage`
+  - `POST /articles/{id}/analyze-coverage`
+
+## Web UX alignment notes
+- Web feed signal readability now mirrors mobile interaction intent without changing API contracts:
+  - `SentimentDot` includes directional icon + text label for non-color encoding.
+  - `LeanPill` and `FrameworkCue` provide at-a-glance feed context while full framework analysis remains on detail/analytics routes.
+- `_app.feed` filter controls expose better semantics (`aria-pressed`, input labels) and stronger keyboard focus treatment.
+- Shared UI primitives now drive filter interactions:
+  - `FilterChip` for selected/unselected chip state hierarchy.
+  - `FilterSelect` wrapper around Radix select for consistent feed control affordance.
+- Type safety hardening:
+  - Required route `search` payloads are now passed for `/feed`, `/preferences`, and `/admin` navigation paths.
+  - URL analyze normalization now coerces `analysis.political_lean` to numeric values before assigning `Article.political_lean`.
+
 ## Output Guardrails
 - Article analysis payload normalization in `backend/app/services/ai_analyzer.py`
   - sentiment bounded to `[-10, 10]`
@@ -28,4 +48,8 @@
 - stage batch sizes (`analysis_batch_size`, etc.)
 - adaptive delay bounds (`pipeline_min_delay_seconds`, `pipeline_max_delay_seconds`)
 - daily budget controls (`pipeline_daily_budget_usd`, `pipeline_warn_budget_percent`)
+
+## Admin recovery
+- `POST /admin/jobs/analyze-recent?limit=N` — background job `analyze_recent_articles_job` uses `get_recent_unanalyzed_article_ids` + optional `target_article_ids` on `analyze_articles_batch`.
+- `process_unprocessed_articles_job` chains extraction when `get_pending_extraction_count` > 0, then unanalyzed analysis, then framework-gap processing.
 

--- a/llm_project_overview.md
+++ b/llm_project_overview.md
@@ -10,12 +10,31 @@ Pulse is a backend/frontend system that ingests news articles, analyzes them wit
   - Content extraction
   - AI article analysis
   - Post-analysis fanout (frameworks, statistics, clustering, context)
+- Manual: `POST /admin/jobs/analyze-recent` (default limit 5) for newest rows missing `ArticleAnalysis`; `process_unprocessed` now runs extraction when articles are still `PENDING` before relying on “unanalyzed” counts.
 
 ## Primary Reliability Controls
 - Job execution tracking in `JobExecutionHistory`
 - Advisory-lock based duplicate run protection
 - Shared retry/backoff utility: `backend/app/utils/resilience.py`
 - Configurable retries/timeouts via `backend/app/config.py`
+
+## Mobile App Integration (Expo)
+- Mobile app root now runs from `mobile/app` (Expo Router entrypoint in root package).
+- Expo runtime API base URL is configured via `EXPO_PUBLIC_API_BASE_URL`.
+- Mobile API calls use generated client in `mobile/app/lib/api-client-react` with bearer token injection via `setAuthTokenGetter`.
+- Key mobile-backed route families: auth, feed, articles detail + advanced coverage/viewpoints, analytics, favorites, preferences, and challenge.
+- `GET /articles/{id}` uses optional JWT (`get_optional_user`): guests can open an article from the public feed; `is_favorited` is false without a session. Some sub-routes (coverage, analyze, etc.) may still require login.
+- `mobile/` only contains the `app/` workspace; unused Replit scaffold packages (`artifacts/api-server`, `artifacts/mockup-sandbox`), nested `.git`, and unused `lib/db` were removed to keep the tree lean.
+- Mobile `info/*` stack (`editorial-standards`, `how-we-rate-lean`, `appearance`) is registered in the root Stack as `info` for in-app help from Profile and Analytics.
+
+## Web UI polish (feed parity with mobile)
+- Feed and card surfaces in `frontend/src/routes/_app.feed.tsx` and `frontend/src/components/ArticleCard.tsx` were tuned for faster scanning: reduced vertical density, clearer control affordances, and stronger focus-visible states.
+- Signal presentation moved to clearer hierarchy in `frontend/src/components/Signals.tsx`: lean now uses a compact pill cue, sentiment adds icon + text (not color-only), and verified badge contrast was increased.
+- Feed cards now include a lightweight ethical-framework cue (`FrameworkCue`) while keeping full framework detail on article and analytics pages.
+- Analytics charts in `frontend/src/routes/_app.analytics.tsx` now show explicit legends and framework glossary accordions have a visible chevron affordance.
+- Reusable feed controls now live in `frontend/src/components/ui/filter-chip.tsx` and `frontend/src/components/ui/filter-select.tsx`, with adoption in feed, signup topic selection, and preferences topic subscriptions.
+- CTA hierarchy was normalized on core surfaces (`feed`, `article`, `login`, `signup`, `challenge`) by reusing `frontend/src/components/ui/button.tsx` variants rather than ad-hoc route-level button classes.
+- Frontend route typing was stabilized for required search params (e.g. `/feed`, `/preferences`, `/admin`) so redirects and links include explicit search payloads where required by TanStack route validation.
 
 ## Observability and Cost
 - In-process pipeline metrics utility: `backend/app/utils/pipeline_metrics.py`


### PR DESCRIPTION
## Summary
- add reusable `FilterChip` and `FilterSelect` primitives and migrate feed/signup/preferences filter flows to them
- polish feed/article/challenge signal + CTA hierarchy for better scanability, accessible state cues, and cleaner framework micro-cues
- stabilize frontend lint/type/build by fixing required route search params and analyze/admin typing edge cases, plus formatting baseline updates

## Test plan
- [x] `npm run lint` (frontend)
- [x] `npx tsc --noEmit` (frontend)
- [x] `npm run build` (frontend)
- [ ] Manually verify feed filters/chips/selects across breakpoints
- [ ] Manually verify article/feed/analytics signal consistency and focus behavior
- [ ] Manually verify login/signup/welcome/challenge CTA hierarchy and selection states


Made with [Cursor](https://cursor.com)