### PR TITLE
fix(auth): avoid login 500 on invalid bcrypt hash

### DIFF
--- a/backend/app/utils/auth.py
+++ b/backend/app/utils/auth.py
@@ -29,7 +29,11 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
         password_bytes = password_bytes[:72]
 
     hashed_bytes = hashed_password.encode('utf-8')
-    return bcrypt.checkpw(password_bytes, hashed_bytes)
+    try:
+        return bcrypt.checkpw(password_bytes, hashed_bytes)
+    except ValueError:
+        # Gracefully handle legacy/corrupt password values that are not valid bcrypt hashes.
+        return False
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:

--- a/claude_backend_pipeline.md
+++ b/claude_backend_pipeline.md
@@ -21,4 +21,13 @@
 3. If spend exceeds warning threshold, verify fallback model activation counter.
 4. Use admin/manual job triggers for isolated stage replay if backlog accumulates.
 5. Validate `JobExecutionHistory.result_data` for failure reason codes.
+6. **`process_unprocessed` job** runs pending **extraction** first (so articles are not stuck behind `get_unanalyzed_article_count` only counting `COMPLETED`), then analysis, then always checks analyzed-but-missing-framework backlog.
+7. **`POST /admin/jobs/analyze-recent?limit=5`** runs `analyze_recent_articles_job` to analyze the newest unanalyzed rows (including `PENDING` with `content_text`) without draining the full queue.
+8. **Newsletter job** returns `skipped_reason` and `noop` when Resend is not configured or there are no eligible subscribers (still `success: true` for the HTTP job wrapper).
+9. **Auth login hardening**: `verify_password` now treats invalid/legacy non-bcrypt hashes as a normal auth failure (`False`) instead of raising `ValueError: Invalid salt` and returning 500.
+
+## Mobile consumer notes
+- Expo mobile app now calls backend endpoints directly (bearer JWT) for feed/detail/analytics/favorites/preferences/challenge flows.
+- For mobile testing, keep deployed API reachable via HTTPS and provide the URL through `EXPO_PUBLIC_API_BASE_URL`.
+- `GET /articles/{id}` accepts anonymous callers (optional JWT) so guests can open articles from the public feed; favorite state is omitted or false without a user.
 


### PR DESCRIPTION
## Summary
- catch `ValueError` in `verify_password` so malformed/legacy non-bcrypt hashes no longer crash login with a 500
- return `false` for invalid hashes so auth fails cleanly as invalid credentials
- document the login hardening note in `claude_backend_pipeline.md`

## Test plan
- [ ] Attempt login for a user with a valid bcrypt hash and confirm normal sign-in behavior
- [ ] Attempt login for a user record with an invalid hash and confirm no 500 is thrown
- [ ] Confirm backend logs no longer show `ValueError: Invalid salt` during these attempts

Made with [Cursor](https://cursor.com)